### PR TITLE
docs: add 4O3A Antenna Genius API documentation and PRD

### DIFF
--- a/docs/antgen/403aAntGen.md
+++ b/docs/antgen/403aAntGen.md
@@ -1,0 +1,387 @@
+# 4O3A Antenna Genius 8x2 Integration PRD
+
+## Executive Summary
+
+This document outlines the integration of the 4O3A Antenna Genius 8x2 antenna switch into Log4YM. The Antenna Genius is a network-enabled 8x2 antenna switch that allows two radios (A and B) to independently select from up to 8 configured antennas. This integration will provide real-time antenna status display and allow users to manually select antennas for each radio port directly from the Log4YM interface.
+
+## Background
+
+### What is the 4O3A Antenna Genius 8x2?
+
+The Antenna Genius 8x2 is a high-isolation, network-enabled antenna switch manufactured by 4O3A Signature. Key features:
+
+- **8 Antenna Ports**: Supports up to 8 different antennas
+- **2 Radio Ports**: Two independent radio connections (A and B)
+- **Network Control**: Full TCP/IP control via port 9007
+- **Auto Discovery**: UDP broadcast discovery on port 9007
+- **Real-time Status**: Asynchronous status updates via subscriptions
+- **Band Awareness**: Can automatically switch antennas based on band/frequency
+
+### Problem Statement
+
+Ham radio operators using the Antenna Genius currently need to use the separate Windows utility or manually configure their antenna selection. Integration with Log4YM will provide:
+
+1. Single-pane-of-glass control for all station equipment
+2. Visual indication of current antenna selection for both radios
+3. Quick antenna switching without leaving the logging application
+
+## Technical Research
+
+### API Documentation Reference
+
+The complete API documentation has been cloned to `docs/antgen/wiki/` from the official [4O3A Genius API Docs](https://github.com/4o3a/genius-api-docs/wiki).
+
+### Network Protocol Overview
+
+#### Discovery Protocol (UDP 9007)
+
+The Antenna Genius broadcasts its presence on the local network every 1 second via UDP port 9007:
+
+```
+AG ip=192.168.1.39 port=9007 v=4.0.22 serial=9A-3A-DC name=Ranko_4O3A ports=2 antennas=8 mode=master uptime=3034
+```
+
+Key parameters:
+- `ip`: Device IP address
+- `port`: TCP port for commands (always 9007)
+- `v`: Firmware version
+- `serial`: Unique device identifier
+- `name`: User-defined device name
+- `ports`: Number of radio ports (2 for 8x2)
+- `antennas`: Number of antenna ports (8 for 8x2)
+- `mode`: Stack mode (master/slave)
+
+#### TCP/IP Command Protocol (TCP 9007)
+
+**Connection Prologue:**
+Upon connecting, the device sends: `V<version> AG[ AUTH]`
+- Example: `V4.0.22 AG`
+- `AUTH` suffix indicates WAN connection requiring authentication
+
+**Command Format:**
+```
+C<seq_number>|command<CR>
+```
+- `seq_number`: 1-255, used to match responses to commands
+
+**Response Format:**
+```
+R<seq_number>|<hex_response>|<message>
+```
+- `hex_response`: 0 = success, non-zero = error code
+
+**Status Format (asynchronous):**
+```
+S0|<message>
+```
+
+### Key Commands for Integration
+
+#### 1. Get Antenna List
+```
+C1|antenna list
+```
+Response:
+```
+R1|0|antenna 1 name=Dummy_Load_1 tx=0000 rx=0001 inband=0000
+R1|0|antenna 2 name=Dummy_Load_2 tx=0000 rx=0001 inband=0000
+R1|0|antenna 3 name=EFHW_Dipole tx=0000 rx=0001 inband=0000
+...
+R1|0|
+```
+
+Parameters:
+- `name`: Custom antenna name (underscore for spaces)
+- `tx`: TX band mask (hex) - which bands can transmit on this antenna
+- `rx`: RX band mask (hex) - which bands can receive on this antenna
+- `inband`: Inband mask (hex)
+
+#### 2. Get Radio Port Status
+```
+C2|port get 1    # Port A
+C3|port get 2    # Port B
+```
+Response:
+```
+R2|0|port 1 auto=1 source=AUTO band=5 rxant=3 txant=3 tx=0 inhibit=0
+```
+
+Parameters:
+- `auto`: Auto band detection enabled
+- `source`: Band source (AUTO, MANUAL, FLEX, etc.)
+- `band`: Current band index (0-15)
+- `rxant`: Selected RX antenna (0 = none, 1-8 = antenna number)
+- `txant`: Selected TX antenna (0 = none, 1-8 = antenna number)
+- `tx`: Currently transmitting (0/1)
+- `inhibit`: Port is inhibited from transmitting
+
+#### 3. Set Antenna for Radio Port
+```
+C4|port set 1 rxant=3 txant=3    # Set Port A to antenna 3
+C5|port set 2 rxant=5 txant=5    # Set Port B to antenna 5
+```
+
+#### 4. Subscribe to Status Updates
+```
+C6|sub port all    # Subscribe to all port changes
+C7|sub antenna     # Subscribe to antenna config changes
+C8|sub relay       # Subscribe to relay state changes
+```
+
+After subscription, status messages are received asynchronously:
+```
+S0|port 1 auto=1 source=AUTO band=5 rxant=3 txant=3 tx=0 inhibit=0
+S0|relay tx=00 rx=04 state=04
+```
+
+#### 5. Keepalive
+```
+C9|ping
+```
+Used to maintain connection and prevent timeout.
+
+### Error Codes
+```
+0x00  - OK (success)
+0x01  - Invalid command format
+0x10  - Unknown command
+0x20  - Invalid command parameters
+0x30  - Invalid subscription object
+0xFF  - Client not authorized
+```
+
+## Objectives
+
+### Primary Goals
+
+1. **Device Discovery**: Auto-discover Antenna Genius devices on the local network
+2. **Status Display**: Show current antenna selection for Radio A and Radio B
+3. **Manual Control**: Allow users to click and select antennas for each radio
+4. **Real-time Updates**: Subscribe to status changes and update UI in real-time
+
+### Non-Goals (Future Considerations)
+
+- Band-based automatic antenna switching (relies on rig integration)
+- Antenna configuration (name, band masks)
+- Multiple Antenna Genius support (stacked configurations)
+- FlexRadio integration features
+
+## User Interface Design
+
+### Antenna Genius Panel
+
+Based on the Windows utility design, the panel will display:
+
+```
++----------------------------------+
+|        Antenna Genius            |
+|----------------------------------|
+|    FLEX        |      FLEX       |
+|    12m         |      None       |
+|----------------------------------|
+|  A [Dummy Load 1          ] B    |
+|  A [Dummy Load 2          ] B    |
+|  A [EFHW Dipole        *  ] B    |  <- * indicates selected
+|  A [Spare antenna         ] B    |
+|  ...                             |
++----------------------------------+
+```
+
+Key UI Elements:
+- **Header**: Device name and connection status
+- **Band Indicator**: Current band for each radio (from port status)
+- **Antenna List**: All configured antennas (skip unconfigured ones)
+- **Selection Buttons**: A and B buttons for each antenna row
+  - Highlighted when antenna is selected for that radio
+  - Click to select antenna for that radio
+
+### Color Scheme
+
+Following the existing Log4YM dark theme:
+- Selected antenna for A: Blue highlight (accent-primary)
+- Selected antenna for B: Green highlight (accent-secondary)
+- Antenna name: White text
+- Unconfigured/disabled: Gray/dimmed
+
+## Implementation Plan
+
+### Phase 1: Backend Service
+
+#### 1.1 Create Antenna Genius Service (`AntennaGeniusService.cs`)
+
+```csharp
+public class AntennaGeniusService : BackgroundService
+{
+    // UDP discovery listener
+    // TCP command connection
+    // Status subscription management
+    // SignalR event broadcasting
+}
+```
+
+Responsibilities:
+- Listen for UDP discovery broadcasts
+- Maintain TCP connection to device
+- Parse command responses and status updates
+- Broadcast changes via SignalR
+
+#### 1.2 Data Models (`AntennaGeniusModels.cs`)
+
+```csharp
+public record AntennaInfo(int Id, string Name, ushort TxMask, ushort RxMask);
+public record PortStatus(int PortId, int Band, int RxAnt, int TxAnt, bool IsTx);
+public record AntennaGeniusStatus(
+    string DeviceName,
+    string IpAddress,
+    string Version,
+    bool Connected,
+    List<AntennaInfo> Antennas,
+    PortStatus PortA,
+    PortStatus PortB
+);
+```
+
+#### 1.3 SignalR Events
+
+Add to `ILogHubClient`:
+```csharp
+Task OnAntennaGeniusStatus(AntennaGeniusStatusEvent evt);
+Task OnAntennaGeniusPortChanged(AntennaGeniusPortChangedEvent evt);
+```
+
+Add hub methods:
+```csharp
+Task SelectAntenna(int portId, int antennaId);
+```
+
+### Phase 2: Frontend Plugin
+
+#### 2.1 Create `AntennaGeniusPlugin.tsx`
+
+React component implementing:
+- Connection status indicator
+- Antenna list with selection buttons
+- Real-time status updates via SignalR
+- Click handlers for antenna selection
+
+#### 2.2 State Management
+
+Add to `appStore.ts`:
+```typescript
+interface AntennaGeniusState {
+  connected: boolean;
+  deviceName: string;
+  antennas: AntennaInfo[];
+  portA: PortStatus;
+  portB: PortStatus;
+}
+```
+
+#### 2.3 SignalR Integration
+
+Add event handlers in `useSignalR.ts`:
+- `OnAntennaGeniusStatus`
+- `OnAntennaGeniusPortChanged`
+
+### Phase 3: Configuration
+
+#### 3.1 Settings
+
+- Enable/disable Antenna Genius integration
+- Manual IP address override (optional, uses discovery by default)
+- Device selection (if multiple discovered)
+
+## API Sequence Diagrams
+
+### Connection Sequence
+
+```
+Log4YM Server                    Antenna Genius
+      |                                |
+      |<---- UDP Discovery (1/sec) ----|
+      |                                |
+      |---- TCP Connect :9007 -------->|
+      |<---- V4.0.22 AG ---------------|
+      |                                |
+      |---- C1|antenna list ---------->|
+      |<---- R1|0|antenna 1 name=... --|
+      |<---- R1|0|antenna 2 name=... --|
+      |<---- R1|0| -------------------|
+      |                                |
+      |---- C2|port get 1 ------------>|
+      |<---- R2|0|port 1 auto=1... ----|
+      |                                |
+      |---- C3|port get 2 ------------>|
+      |<---- R3|0|port 2 auto=1... ----|
+      |                                |
+      |---- C4|sub port all ---------->|
+      |<---- R4|0| -------------------|
+      |                                |
+      |---- C5|sub relay ------------->|
+      |<---- R5|0| -------------------|
+      |                                |
+```
+
+### User Selects Antenna
+
+```
+Browser           Log4YM Server           Antenna Genius
+   |                    |                       |
+   |-- SelectAntenna -->|                       |
+   |    (port=1, ant=3) |                       |
+   |                    |---- C6|port set 1 --->|
+   |                    |      rxant=3 txant=3  |
+   |                    |<---- R6|0| -----------|
+   |                    |                       |
+   |                    |<---- S0|port 1... ----|
+   |<-- PortChanged ----|                       |
+   |    (status update) |                       |
+```
+
+## Testing Strategy
+
+### Unit Tests
+- Command parser tests
+- Response parser tests
+- Status message parser tests
+
+### Integration Tests
+- Mock TCP server for command/response testing
+- SignalR event propagation tests
+
+### Manual Testing
+- Real device connection testing
+- UI interaction testing
+- Network failure/reconnection testing
+
+## Configuration Options
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `AntennaGenius:Enabled` | bool | false | Enable AG integration |
+| `AntennaGenius:IpAddress` | string | null | Manual IP (auto-discover if null) |
+| `AntennaGenius:Port` | int | 9007 | TCP port |
+| `AntennaGenius:ReconnectDelay` | int | 5000 | Reconnect delay in ms |
+| `AntennaGenius:KeepAliveInterval` | int | 30000 | Ping interval in ms |
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Network instability | Connection drops | Auto-reconnect with backoff |
+| Multiple AG devices | Confusion | Device selector in settings |
+| Firmware incompatibility | Protocol errors | Version check on connect |
+| UDP discovery blocked | No auto-discover | Manual IP configuration |
+
+## Success Metrics
+
+1. Successful auto-discovery of Antenna Genius on local network
+2. Real-time antenna status display (< 100ms latency)
+3. Successful antenna switching via UI
+4. Graceful handling of connection loss/recovery
+
+## References
+
+- [4O3A Antenna Genius Product Page](https://4o3a.com/products/genius-family/antenna-genius)
+- [Antenna Genius API Documentation](https://github.com/4o3a/genius-api-docs/wiki)
+- Local API docs: `docs/antgen/wiki/`

--- a/docs/antgen/wiki/Antenna-Genius-API.md
+++ b/docs/antgen/wiki/Antenna-Genius-API.md
@@ -1,0 +1,4 @@
+The Antenna Genius (AG) Ethernet API has a number of distinct pieces:
+
+1. [Discovery protocol](Antenna-Genius-Discovery-protocol) which announces the AG's presence on the local network for facilitating client connections sent to UDP port 9007
+2. The [Antenna Genius TCPIP API](Antenna-Genius-TCPIP-API) which is used to command the device and receive status information from the AG. The command API uses TCP/IP port 9007.

--- a/docs/antgen/wiki/Antenna-Genius-Discovery-protocol.md
+++ b/docs/antgen/wiki/Antenna-Genius-Discovery-protocol.md
@@ -1,0 +1,20 @@
+Antenna Genius Discovery protocol broadcasts the device information on the local area network (LAN) via UDP on port 9007.
+
+UDP broadcasted message is formatted as a string that starts with 'AG' followed by multiple property=value pairs separated by white space: _AG ip=%u.%u.%u.%u port=%u v=%u.%u.%u serial=%s name=%s ports=%u antennas=%u mode=%s uptime=%u_
+
+Example:
+```
+AG ip=192.168.1.39 port=9007 v=4.0.22 serial=9A-3A-DC name=Ranko_4O3A ports=2 antennas=8 mode=master uptime=3034
+
+ip        = LAN IP address for client connection(s)
+port      = TCP port for client connection(s)
+v         = firmware version installed
+serial    = unique serial number generated based on network adapter MAC address (last six hex numbers)
+name      = user-defined network name
+ports     = number of radio ports available
+antennas  = number of antenna ports available
+mode      = AG stack operating mode [master|slave]
+uptime    = number of seconds since the last power-on
+```
+
+UDP packet with the above information is broadcasted on the local area network every 1 second by every connected Antenna Genius device.

--- a/docs/antgen/wiki/Antenna-Genius-Status-Messages.md
+++ b/docs/antgen/wiki/Antenna-Genius-Status-Messages.md
@@ -1,0 +1,31 @@
+### ANTENNA
+A status message indicating antenna configuration has been changed, which is received by the clients subscribed to antenna changes: [sub antenna](Antenna-Genius-TCPIP-sub#ANTENNA)
+```
+S0|antenna reload
+```
+After receiving such a message, the client must reload the antenna configuration using the [antenna list](Antenna-Genius-TCPIP-antenna#LIST) command.
+
+### OUTPUT
+A status message indicating output(s) configuration has been changed, which is received by the clients subscribed to output changes: [sub output](Antenna-Genius-TCPIP-sub#OUTPUT)
+```
+S0|output reload
+```
+After receiving such a message, the client must reload the output(s) configuration using the [group list](Antenna-Genius-TCPIP-group#LIST) and [output list](Antenna-Genius-TCPIP-output#LIST) commands.
+### PORT
+A status message indicating radio port status has been changed, which is received by the clients subscribed to port changes: [sub port](Antenna-Genius-TCPIP-sub#PORT)
+```
+S0|port 1 auto=1 source=AUTO band=0 rxant=0 txant=0 inband=0 tx=0 inhibit=0
+S0|port 2 auto=1 source=AUTO band=0 rxant=0 txant=0 inband=0 tx=0 inhibit=0
+```
+The format of the message is the same as when parsing the [port get](Antenna-Genius-TCPIP-port#GET) command.
+
+### RELAY
+A status message indicating the output(s) or relay(s) state has been changed, which is received by the clients subscribed to relay changes: [sub relay](Antenna-Genius-TCPIP-sub#RELAY)
+```
+S0|relay tx=00 rx=00 state=00
+```
+| Parameter | Value|
+|---|---|
+|tx|Reserved for future use|
+|rx|Hex representation of selected output(s)|
+|state|Hex representation of active relay(s)|

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-API.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-API.md
@@ -1,0 +1,75 @@
+The Antenna Genius (AG) TCP/IP API performs the following functions:
+
+1. Issuing [commands](Antenna-Genius-TCPIP-API#antenna-genius-tcpip-commands) to the AG
+2. Asynchronously receiving [status information](Antenna-Genius-TCPIP-API#antenna-genius-tcpip-statuses) from the AG
+3. Locating AG devices via the [discovery protocol](Antenna-Genius-Discovery-protocol)
+
+The command API is accessed using a TCP/IP socket connection to port 9007 of the AG. To locate AG devices on the local network, use the [discovery protocol](Antenna-Genius-Discovery-protocol)
+
+## TCP/IP Command Protocol
+### Command Prologue
+Upon connecting to the client port, Antenna Genius will provide the firmware version installed, followed by the 'AG' identifier, and optional 'AUTH' phrase if the client connection is initiated from WAN. 
+
+This information is provided each time the client connects to the Antenna Genius.
+```
+V<a.b.c> AG[ AUTH]
+
+V          = indicates version information
+<a.b.c>    = major version number in decimal '.' minor version number in decimal '.' build version number in decimal
+AG         = indicates the type of the device (Antenna Genius = AG)
+AUTH       = if the client connection is initiated from WAN, the client must authenticate itself
+```
+### Command Format
+Once the connection is established, the client may begin sending commands to the device. Commands follow a general ASCII format. Command format (from client to device):
+```
+C<seq_number>|command<terminator>
+
+C             = indicates a command
+<seq_number>  = sequence number, numeric, 1 to 255
+<terminator>  = 0x0D
+```
+### Response Format
+All commands receive responses from the device. At least one response will be sent for each command received by the client. The response is tied to the command by the sequence number supplied by the client. This sequence number will be echoed back to the client in the response. The client should check the hex response to determine if the command issued was successful. A zero (0) value indicates success. Any other value represents a failure of the command to execute. The response value is unique and provides insight into the failure mode. It is recommended that any decisions that are made by the client based on a response should use the hexadecimal response to make the decisions. Response Format (from device to client):
+```
+R<seq_number>|<hex_response>|<message>
+
+<seq_number>   = numeric, up to 32-bits -- echoed from the command sent from the client
+<hex response> = ASCII hexadecimal number (32-bit) return value (see table below for possibilities)
+<message>      = response value for parsing
+```
+A list of responses can be found on the [Known API responses](Known-API-responses) page.
+### Status Format
+Objects in the device will send out status when they are changed. To find out about objects, the client must have either subscribed to the status for the object. Status messages are asynchronous and can be sent to the client at any time. Status Format (from device to client):
+```
+S<0>|<message>
+
+<0>         = reserved for future use
+<message>   = status value for parsing
+```
+The period character is used as a decimal separator independent of the locale.
+
+A detailed list of status responses can be found in [Status Responses](Antenna-Genius-TCPIP-API#tcpip-statuses)
+
+## TCP/IP Commands
+- [antenna](Antenna-Genius-TCPIP-antenna) → list and configure antenna port(s)
+- [auth](Antenna-Genius-TCPIP-auth) → authenticate clients connected from outside of the local area network
+- [band](Antenna-Genius-TCPIP-band) → list and configure band(s)
+- [conf](Antenna-Genius-TCPIP-conf) → get configuration properties, factory reset the configuration
+- [flex](Antenna-Genius-TCPIP-flex) → configuring integration with FlexRadio
+- [group](Antenna-Genius-TCPIP-group) → list and configure output group(s)
+- [info](Antenna-Genius-TCPIP-info) → get device basic info
+- [keepalive](Antenna-Genius-TCPIP-keepalive) → enable or disable keepalive mechanism
+- [network](Antenna-Genius-TCPIP-network) → network parameter configuration
+- [output](Antenna-Genius-TCPIP-output) → list and configure output(s)
+- [ping](Antenna-Genius-TCPIP-ping) → inform the keepalive mechanism that the client is active
+- [port](Antenna-Genius-TCPIP-port) → list and configure radio port(s)
+- [reboot](Antenna-Genius-TCPIP-reboot) → reboot the device
+- [stack](Antenna-Genius-TCPIP-stack) → configuring AG stack
+- [sub](Antenna-Genius-TCPIP-sub) → subscribe to a specific status messages
+- [unsub](Antenna-Genius-TCPIP-unsub) → unsubscribe from a specific status messages
+## TCP/IP Statuses
+- [antenna](Antenna-Genius-Status-Messages#ANTENNA) → propagation of antenna changes
+- [group](Antenna-Genius-Status-Messages#GROUP) → propagation of output group changes
+- [output](Antenna-Genius-Status-Messages#OUTPUT) → propagation of output changes
+- [port](Antenna-Genius-Status-Messages#PORT) → propagation of port changes
+- [relay](Antenna-Genius-Status-Messages#RELAY) → propagation of output relay status

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-antenna.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-antenna.md
@@ -1,0 +1,60 @@
+### LIST
+This command lists the available antennas on the device
+```
+C<seq_number>|antenna list
+```
+Example:
+```
+C5|antenna list
+```
+
+The command will return the antenna configuration table in multiple responses with the same <seq_number>, containing a message with the antenna configuration, prior to returning the OK status.
+
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R5|0|antenna 1 name=Antenna_1 tx=0000 rx=0001 inband=0000
+R5|0|antenna 2 name=Antenna_2 tx=0000 rx=0001 inband=0000
+R5|0|antenna 3 name=Antenna_3 tx=0000 rx=0001 inband=0000
+R5|0|antenna 4 name=Antenna_4 tx=0000 rx=0001 inband=0000
+R5|0|antenna 5 name=Antenna_5 tx=0000 rx=0001 inband=0000
+R5|0|antenna 6 name=Antenna_6 tx=0000 rx=0001 inband=0000
+R5|0|antenna 7 name=Antenna_7 tx=0000 rx=0001 inband=0000
+R5|0|antenna 8 name=Antenna_8 tx=0000 rx=0001 inband=0000
+R5|0|
+```
+| Parameter | Value|
+|---|---|
+|id|Antenna identifier 1 - xx|
+|name|Custom antenna name|
+|tx|TX band mask (hex)|
+|rx|RX band mask (hex)|
+|inband|Inband band mask (hex)|
+
+Parameters like **tx**, **rx**, and **inband** are masks that represent if the antenna is available on a certain band (0-15) where each bit represents a band. 
+
+Example: 0b0000000000000111 masks the antenna to be available on the first 3 configured bands and its hex value is **0x0007**, thus a returned value would be 0007
+
+### SET
+This command is used to configure antenna port parameters.
+```
+C<seq_number>|antenna set <antenna_no> [name=<name>] [tx=<tx>] [rx=<rx>] [inband=<inband>]
+
+<antenna_no>  = antenna identifier (1-xx)
+<name>        = custom antenna name
+<tx>          = tx band mask
+<rx>          = rx band mask
+<inband>      = inband band mask
+```
+Example:
+```
+C7|antenna set 3 name=My_antenna tx=0007 rx=0007 inband=0000
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R7|0|
+```
+Whenever the antenna name is changed, each connected client that previously executed [sub antenna](Antenna-Genius-TCPIP-sub#ANTENNA) will receive the [antenna reload](Antenna-Genius-Status-Messages#ANTENNA) update status indicating that the antenna name(s) has changed.

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-auth.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-auth.md
@@ -1,0 +1,37 @@
+### AUTH
+Authorizes the client to control the device if the connection is established from WAN
+```
+C<seq_number>|auth code=<code>
+
+<code>  = authorization code, previously configured via the 'network' command
+```
+Example:
+```
+C54|auth code=123456
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R54|0|  // OK - client authorized
+```
+
+```
+R54|FF|  // Incorrect authorization code - client not authorized
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-band.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-band.md
@@ -1,0 +1,77 @@
+### LIST
+This command is used to list the available band slots (0-15) on the device, based on which it detects the correct band by comparing the frequency retrieved from any reliable frequency source (FLEX, LAN, etc.)
+```
+C<seq_number>|band list
+```
+Example:
+```
+C9|band list
+```
+
+The command will return the band configuration table in multiple responses with the same <seq_number>, containing a message with band configuration, prior to returning the OK status.
+
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R9|0|band 0 name=None freq_start=0.000000 freq_stop=0.000000
+R9|0|band 1 name=160m freq_start=1.600000 freq_stop=2.200000
+R9|0|band 2 name=80m freq_start=3.300000 freq_stop=4.000000
+R9|0|band 3 name=40m freq_start=6.800000 freq_stop=7.400000
+R9|0|band 4 name=30m freq_start=9.900000 freq_stop=10.350000
+R9|0|band 5 name=20m freq_start=13.800000 freq_stop=14.550000
+R9|0|band 6 name=17m freq_start=17.868000 freq_stop=18.368000
+R9|0|band 7 name=15m freq_start=20.800000 freq_stop=21.650000
+R9|0|band 8 name=12m freq_start=24.690000 freq_stop=25.190000
+R9|0|band 9 name=10m freq_start=27.800000 freq_stop=29.900000
+R9|0|band 10 name=6m freq_start=49.800000 freq_stop=52.200000
+R9|0|band 11 name=60m freq_start=5.000000 freq_stop=6.000000
+R9|0|band 12 name=Custom_1 freq_start=0.000000 freq_stop=0.000000
+R9|0|band 13 name=Custom_2 freq_start=0.000000 freq_stop=0.000000
+R9|0|band 14 name=Custom_3 freq_start=0.000000 freq_stop=0.000000
+R9|0|band 15 name=Custom_4 freq_start=0.000000 freq_stop=0.000000
+R9|0|
+```
+| Parameter | Value|
+|---|---|
+|id|Band identifier 0 - 15|
+|name|Custom band name|
+|freq_start|Frequency start|
+|freq_stop|Frequency stop|
+
+### SET
+All bands are configurable in terms of name, start frequency, and end frequency upon which the device will detect the current band.
+```
+C<seq_number>|band set <band_id> [name=<name>] [freq_start=<freq_start>] [freq_stop=<freq_stop>]
+
+<band_id>     = band identifier (1-15). Cannot be 0 as it is reserved for a None band / no band data
+<name>        = custom band name
+<freq_start>  = frequency start
+<freq_stop>   = frequency stop
+```
+Example:
+```
+C7|band set 12 name=My_special_band freq_start=5.000000 freq_stop=5.200000
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R7|0|
+```
+
+### INIT
+Initializes band configuration to a factory defaults.
+```
+C<seq_number>|band init
+```
+Example:
+```
+C11|band init
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R11|0|
+```

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-conf.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-conf.md
@@ -1,0 +1,50 @@
+### GET
+This command is used to get the configuration properties of the device
+```
+C<seq_number>|conf get
+```
+Example:
+```
+C64|conf get
+```
+Response Example:
+```
+C64|0|conf name=Antenna_Genius inband_port=0
+
+<name>         = user-defined network name
+<inband_port>  = inband port number (0=not configured, 1=A, 2=B)
+```
+### SET
+This command is used to set the configuration properties of the device
+```
+C<seq_number>|conf set [name=<name>] [inband_port=<port_number>]
+
+<name>         = user-defined network name
+<port_number>  = inband port number (0=not configured, 1=A, 2=B)
+```
+Example:
+```
+C7|conf set name=Ranko_4O3A inband_port=2
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R7|0|
+```
+### INIT
+This command is used to initialize device configuration to a factory default.
+
+Note: This command will [reboot](Antenna-Genius-TCPIP-reboot) the device automatically after the command is executed.
+```
+C<seq_number>|conf init
+```
+Example:
+```
+C64|conf init
+```
+Response Example:
+```
+C64|0|
+```
+Approximately 1 second after the command is executed, the device will reboot and initialize the configuration to a factory default.

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-flex.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-flex.md
@@ -1,0 +1,71 @@
+### LIST
+This command is used to list the available FlexRadio devices connected to a LAN.
+
+```
+C<seq_number>|flex list
+```
+Example:
+```
+C77|flex list
+```
+
+The command will return the list of discovered radios in multiple responses with the same <seq_number>, containing a message with radio information prior to returning the OK status.
+
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R77|0|flex model=FLEX-6700 serial=1514-3143-6700-7544 nickname=Ranko callsign=4O3A
+R77|0|
+```
+| Parameter | Value|
+|---|---|
+|model|FlexRadio model|
+|serial|Serial number - used to bind to the AG device|
+|nickname|Radio nickname|
+|callsign|Configured callsign|
+
+### GET
+Gets the per-port (A and B) integration configuration parameters
+```
+C<seq_number>|flex get <port_id>
+
+<port_id>   = Port identifier / 1=A, 2=B
+```
+Example:
+```
+C12|flex get 1
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R12|0|flex 1 serial= ant=ANT2 ptt=LAN
+```
+| Parameter | Value|
+|---|---|
+|id|Port identifier|
+|serial|Configured serial number|
+|ant|Port connected to antenna port|
+|ptt|PTT source - LAN or RCA|
+
+### SET
+Configuring AG-FlexRadio port integration
+```
+C<seq_number>|flex set <port_id> serial=<serial_no> ant=<antenna_port> ptt=<ptt_source>
+
+<port_id>        = Port identifier
+<serial_no>      = Radio serial number for binding
+<antenna_port>   = AG port is connected to: ANT1, ANT2, XVRT
+<ptt_source>     = PTT source: LAN or RCA
+```
+Example:
+```
+C8|flex set 1 serial=1514-3143-6700-7544 ant=ANT1 ptt=LAN
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R8|0|
+```

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-group.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-group.md
@@ -1,0 +1,53 @@
+### LIST
+This command is used to list the available output groups.
+
+```
+C<seq_number>|group list
+```
+Example:
+```
+C56|group list
+```
+The command will return the list of configured output groups in multiple responses with the same <seq_number>, containing a message with group information prior to returning the OK status.
+
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R56|0|group 1 in_use=1 name=Group_1 mode=ANT antenna=1 allow_none=1
+R56|0|group 2 in_use=1 name=Group_2 mode=BAND bands=0004 allow_none=1
+R56|0|
+```
+| Parameter | Value|
+|---|---|
+|id|Group identifier|
+|in_use|Is the group in use|
+|name|User-defined name|
+|mode|Group mode / ANT or BAND|
+|antenna|Group active when antenna port selected|
+|bands|Bands mask (hex) - the group is active when any of the masked band is active|
+|allow_none|Allow no active output inside the group|
+
+### SET
+Configures output group
+```
+C<seq_number>|group set <group_id> in_use=<in_use> name=<name> mode=<ANT|BAND> [antenna=<antenna>|bands=<bands>] allow_none=<allow_none>
+
+<group_id>    = Group identifier
+<in_use>      = Group is in use
+<name>        = User-defined group name
+<mode>        = Group mode / ANT or BAND
+<antenna>     = Antenna selection (ANT mode)
+<bands>       = Band(s) selection (BAND mode)
+<allow_none>  = Allow no active output selected in the group
+```
+Example:
+```
+C17|group set 2 in_use=1 name=Group_2 mode=BAND bands=3 allow_none=1
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R17|0|
+```

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-info.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-info.md
@@ -1,0 +1,27 @@
+### GET
+Gets the device firmware, hardware and capability information
+```
+C<seq_number>|info get
+```
+Example:
+```
+C54|info get
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R54|0|info v=4.0.22 date=2023-08-22 btl=1.6 hw=2.0 serial=9A-3A-DC name=Antenna_Genius ports=2 antennas=8 mode=master uptime=3600
+```
+| Parameter | Value|
+|---|---|
+|v|Firmware version installed|
+|date|Firmware build date|
+|btl|Bootloader version|
+|hw|Device hardware version|
+|serial|Unique serial number generated based on network adapter MAC address|
+|name|User-defined network name|
+|ports|Number of radio ports available|
+|antennas|Number of antenna ports available|
+|mode|AG stack operating mode [master or slave]|
+|uptime|Number of seconds since the last power-on|

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-keepalive.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-keepalive.md
@@ -1,0 +1,35 @@
+### KEEPALIVE
+Authorizes the client to control the device if the connection is established from WAN
+```
+C<seq_number>|keepalive enable|disable
+```
+Example:
+```
+C19|keepalive enable
+```
+See [Response Format](https://github.com/4o3a/genius-api-docs/wiki/Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+| Hex Response | Meaning |
+|---|---|
+|0x00|OK authorized|
+|0x20|Invalid command parameters|
+
+Response Example:
+```
+R19|0|
+```
+
+With the TCP Channel Keep-alive mechanism enabled, the device expects to receive a ping command from the client once per second. If 5 seconds elapse without a [ping command](Antenna-Genius-TCPIP-ping), the client will be disconnected and the socket will be closed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-network.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-network.md
@@ -1,0 +1,44 @@
+### GET
+Get device network configuration
+```
+C<seq_number>|network get
+```
+Example:
+```
+C34|network get
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+R34|0|network dhcp=1 address=192.168.1.39 netmask=255.255.255.0 gateway=192.168.1.1 auth=213456
+```
+| Parameter | Value|
+|---|---|
+|dhcp|DHCP enabled (0 or 1)|
+|address|Primary IP address|
+|netmask|Network mask|
+|gateway|Default gateway|
+|auth|WAN auth password|
+### SET
+Configure device network parameters
+```
+C<seq_number>|network set [dhcp=0|1] [address=<address>] [netmask=<netmask>] [gateway=<gateway>] [auth=<auth>]
+
+<dhcp>      = DHCP 1=enable or 0=disable
+<address>   = Primary IP address
+<netmask>   = Netmask
+<gateway>   = Default gateway
+<auth>      = Remote access password
+```
+Example:
+```
+C22|network dhcp=1 address=192.168.1.39 netmask=255.255.255.0 gateway=192.168.1.1 auth=123456
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+R22|0|
+```
+When DHCP changes, the device will reboot automatically. Additionally, if DHCP is disabled and any of the addresses are changed, the device will reboot automatically.

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-output.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-output.md
@@ -1,0 +1,74 @@
+### LIST
+This command is used to list the available outputs.
+
+```
+C<seq_number>|output list
+```
+Example:
+```
+C1|output list
+```
+The command will return the list of configured outputs in multiple responses with the same <seq_number>, containing a message with output configuration prior to returning the OK status.
+
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R1|0|output 1 in_use=1 group=1 name=Output_1 state=01 hotkey=0 trx=0
+R1|0|output 2 in_use=1 group=1 name=Output_2 state=08 hotkey=0 trx=0
+R1|0|output 3 in_use=1 group=1 name=Output_3 state=40 hotkey=0 trx=0
+R1|0|
+```
+| Parameter | Value|
+|---|---|
+|id|Group identifier|
+|in_use|Is the output in use|
+|group|Output parent identifier|
+|name|User-defined name|
+|state|Relay state when output is active (hex)|
+|hotkey|Global keyboard combination (for Windows Utility)|
+|trx|Output toggles (turns off) other output(s) in the same group|
+
+### SET
+Configures outputs
+```
+C<seq_number>|output set <output_id> [(active=<0|1>)|(in_use=<in_use> group=<group_id> name=<name> state=<state> hotkey=<hotkey> trx=<trx>)]
+
+<output_id>   = Output identifier
+<active>      = Activated/deactivates output
+<in_use>      = Group is in use
+<group_id>    = Parent group identifier
+<name>        = User-defined group name
+<state>       = Relay state when output is active (hex)
+<hotkey>      = Global keyboard combination (for Windows Utility)
+<trx>         = Output toggles (turns off) other output(s) in the same group
+```
+Example:
+```
+C17|output set 1 in_use=1 group=1 name=Output_1 mask=01 state=01 hotkey=0 trx=0
+
+C18|output set 1 active=1
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R17|0|
+
+R18|0|
+```
+### INIT
+Initializes output configuration - mandatory before configuring group(s) and output(s).
+```
+C<seq_number>|output init
+```
+Example:
+```
+C67|output init
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R67|0|
+```

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-ping.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-ping.md
@@ -1,0 +1,15 @@
+### PING
+Pings the device to check if it is still running
+
+```
+C<seq_number>|ping
+```
+Command Example:
+```
+C19|ping
+```
+Response Example:
+```
+R19|0|
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-port.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-port.md
@@ -1,0 +1,50 @@
+### GET
+Gets the radio port information
+```
+C<seq_number>|port get <port_id>
+
+<port_id>   = Radio port on AG / A=1  B=2
+```
+Example:
+```
+C15|port get 1
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+R15|0|port 1 auto=1 source=AUTO band=0 rxant=0 txant=0 tx=0 inhibit=0
+```
+| Parameter | Value|
+|---|---|
+|id|Port identifier 1=A 2=B|
+|auto|Autodetect band source|
+|source|Band source|
+|band|Band identifier 0-15|
+|rxant|Selected RX antenna (0 = none)|
+|txant|Selected TX antenna (0 = none)|
+|tx|Port is in transpission|
+|inhibit|Port is inhibited - prevented from transmitting or using current band|
+
+### SET
+Setting radio port parameters
+```
+C<seq_number>|port set <port_id> [auto=<0|1>] [source=<band_source>] [band=<band>] [rxant=<antenna>] [txant=<antenna>]
+
+<port_id>       = Port identifier 1=A 2=B
+<auto>          = Autodetect band source
+<band_source>   = Band source
+<band>          = Band identifier 0-15
+<antenna>       = Antenna identifier 0-xx (0 = none)
+```
+
+Example:
+```
+C22|port set 1 auto=0 source=MANUAL band=3 rxant=1 txant=1
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+C22|0|
+```

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-reboot.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-reboot.md
@@ -1,0 +1,13 @@
+### REBOOT
+Restart (reboot) the device. When this command is issued, the device will drop all connections and will be unresponsive for approximately 20 seconds while a reboot occurs.
+```
+C<seq_number>|reboot
+```
+Example:
+```
+C1|reboot
+```
+Response Example:
+```
+R1|0|
+```

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-stack.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-stack.md
@@ -1,0 +1,68 @@
+### LIST
+Lists available AG devices on LAN to pair (stack) together.
+```
+C<seq_number>|stack list
+```
+Example:
+```
+C16|stack list
+```
+
+The command will return the available AG table in multiple responses with the same <seq_number>, containing a message with the AG information, prior to returning the OK status.
+
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response example:
+```
+R16|0|stack serial=C7-F6-5C name=Antenna_Genius antennas=8 ports=2
+R16|0|stack serial=92-3A-DC name=Antenna_Genius antennas=8 ports=2
+R16|0|
+```
+| Parameter | Value|
+|---|---|
+|serial|AG serial number - used for stacking|
+|name|Custom set device name|
+|antennas|Number of antenna ports on the device|
+|ports|Number of radio ports on the device|
+
+### GET
+Gets the configured values for AG stacking
+```
+C<seq_number>|stack get
+```
+Example:
+```
+C17|stack get
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+R17|0|stack in_use=1 serial=9A-3A-DC mode=1
+```
+| Parameter | Value|
+|---|---|
+|in_use|Boolean representing if stacking is enabled|
+|serial|AG serial number - used for stacking|
+|mode|Stacking mode - 0 = A/B switch, 1 = Using ports 7&8|
+
+### SET
+This command is used to configure stack parameters.
+```
+C<seq_number>|stack set <in_use> [serial=<serial_no>] [mode=<mode>]
+
+<in_use>      = boolean representing if stacking is enabled
+<serial>      = AG serial number
+<mode>        = Stacking mode - 0 = A/B switch, 1 = Using ports 7&8
+```
+Example:
+```
+C7|stack in_use=1 serial=AB-CD-EF mode=1
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the device
+
+Response Example:
+```
+R7|0|
+```
+Whenever the mode is changed, each connected client that previously executed [sub antenna](Antenna-Genius-TCPIP-sub#ANTENNA) will receive the [antenna reload](Antenna-Genius-Status-Messages#ANTENNA) update status indicating that the antenna list has changed.

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-sub.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-sub.md
@@ -1,0 +1,51 @@
+### Overview
+This command will subscribe to messages produced by the device to inform a client of the status of certain objects. Once a subscription has been enabled, status messages will be sent to the client for changes in the object that is the target of the subscription. 
+
+Available objects are:
+- [antenna](#ANTENNA)
+- [group](#GROUP)
+- [output](#OUTPUT)
+- [port](#PORT)
+- [relay](#RELAY)
+
+In the event that a subscription request is made for an object that does not exist, the following response will be generated:
+
+To unsubscribe from an object, use the [unsub](Antenna-Genius-TCPIP-unsub) command. This will revert the previous subscription command and discontinue status messages about the object.
+
+### PORT
+Subscribe to the status of radio ports (A=1, B=2, or both)
+```
+C<seq_number>|sub port <port_number|all>
+
+<port_number|all>  = port number (A=1, B=2) or all to subscribe to all ports available on the device
+```
+
+Example:
+```
+C21|sub port all
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+R21|0|
+```
+After a successful subscription to an available port, API will start sending asynchronous updates of port changes via [port](Antenna-Genius-Status-Messages#PORT) Status message
+
+### RELAY
+Subscribe to the output relay board and output(s) changes
+```
+C<seq_number>|sub relay
+```
+
+Example:
+```
+C21|sub relay
+```
+See [Response Format](Antenna-Genius-TCPIP-API#response-format) for details on the format of the response messages from the radio
+
+Response Example:
+```
+R21|0|
+```
+After a successful subscription to an output relay, API will start sending asynchronous updates of relay changes changes via [relay](Antenna-Genius-Status-Messages#RELAY) Status message

--- a/docs/antgen/wiki/Antenna-Genius-TCPIP-unsub.md
+++ b/docs/antgen/wiki/Antenna-Genius-TCPIP-unsub.md
@@ -1,0 +1,20 @@
+### UNSUB
+Unsubscribe stops a subscription that is in process for the objects that are listed in the unsub command. Subscriptions provide status messages for objects that are changed in the device, typically by the device itself. The general format of the unsubscribe command is:
+```
+C<seq_number>|unsub <object> <object_id|all>
+
+<object>         = the object that is the target of the command such as 'port', 'output', or 'relay'
+<object_id|all>  = the specific number or identifier of the object to be unsubscribed from or the word "all" to unsubscribe to all
+```
+The complete list of objects that can be subscribed to / unsubscribed from can be found in the [sub command page](Antenna-Genius-TCPIP-sub) noting that the command unsub should replace the sub command seen on that page.
+
+See [Response Format](Antenna-Genius-TCPIP-API#Response-Format) for details on the format of the response messages from the radio
+| Hex Response | Meaning |
+|---|---|
+| 0x00 | OK unsubscribed |
+| 0x30 | Invalid subscription object |
+
+Response Example:
+```
+R43|0|
+```

--- a/docs/antgen/wiki/Home.md
+++ b/docs/antgen/wiki/Home.md
@@ -1,0 +1,10 @@
+## Ethernet API
+* [Antenna Genius API v4](Antenna-Genius-API)
+  * [Discovery protocol](Antenna-Genius-Discovery-protocol)
+  * [TCP/IP API](Antenna-Genius-TCPIP-API)
+
+
+
+
+
+[Known API responses](Known-API-responses)

--- a/docs/antgen/wiki/Known-API-responses.md
+++ b/docs/antgen/wiki/Known-API-responses.md
@@ -1,0 +1,11 @@
+The 4O3A Genius API can produce a number of error codes that provide clues about why a particular command failed. This list contains the list of errors, warnings and information codes that exist in the API.
+
+```
+#define CLIENT_ERROR_BASE       0x00                        // OK
+    
+#define CLIENT_ERROR_FORMAT     CLIENT_ERROR_BASE + 0x001   // Invalid command format
+#define CLIENT_ERROR_UNKNOWN    CLIENT_ERROR_BASE + 0x010   // Unknown command
+#define CLIENT_ERROR_COMMAND    CLIENT_ERROR_BASE + 0x020   // Invalid command parameters
+#define CLIENT_ERROR_SUBOBJ     CLIENT_ERROR_BASE + 0x030   // Invalid subscription object
+#define CLIENT_ERROR_AUTH       CLIENT_ERROR_BASE + 0x0FF   // Client not authorized
+```

--- a/docs/antgen/wiki/_Footer.md
+++ b/docs/antgen/wiki/_Footer.md
@@ -1,0 +1,1 @@
+![4o3a-logo-app](https://github.com/4o3a/genius-api-docs/assets/24666921/38fe9ce7-5f60-4a38-9d8a-87d907b21005)


### PR DESCRIPTION
- Clone official API wiki from github.com/4o3a/genius-api-docs
- Create PRD for Antenna Genius 8x2 integration feature
- Document TCP/IP command protocol and UDP discovery
- Define UI design and implementation plan