### PR TITLE
HAmlib fixes

### DIFF
--- a/src/Log4YM.Contracts/Events/LogEvents.cs
+++ b/src/Log4YM.Contracts/Events/LogEvents.cs
@@ -513,7 +513,9 @@ public record HamlibRigCapabilities(
     bool CanSendMorse,
     int DefaultDataBits,
     int DefaultStopBits,
-    bool IsNetworkOnly
+    bool IsNetworkOnly,
+    bool SupportsSerial,
+    bool SupportsNetwork
 );
 
 /// <summary>

--- a/src/Log4YM.Server/Hubs/LogHub.cs
+++ b/src/Log4YM.Server/Hubs/LogHub.cs
@@ -437,7 +437,9 @@ public class LogHub : Hub<ILogHubClient>
             caps.CanSendMorse,
             caps.DefaultDataBits,
             caps.DefaultStopBits,
-            caps.IsNetworkOnly
+            caps.IsNetworkOnly,
+            caps.SupportsSerial,
+            caps.SupportsNetwork
         );
 
         await Clients.Caller.OnHamlibRigCaps(new HamlibRigCapsEvent(modelId, capsDto));

--- a/src/Log4YM.Server/Native/Hamlib/HamlibInterop.cs
+++ b/src/Log4YM.Server/Native/Hamlib/HamlibInterop.cs
@@ -59,14 +59,16 @@ public sealed class HamlibRig : IDisposable
     {
         ThrowIfDisposed();
 
-        // Access rig->state.rigport struct via offset
-        // This is fragile but necessary for direct Hamlib access
-        // We'll use rig_set_conf for portable configuration
+        // Normalize Windows COM port paths
+        // COM ports >= 10 or with certain drivers need \\.\COMx format
+        var normalizedPath = NormalizeSerialPortPath(portPath);
+        _logger?.LogInformation("Configuring serial port: {OriginalPath} -> {NormalizedPath}",
+            portPath, normalizedPath);
 
         lock (_lock)
         {
             // Set pathname
-            SetConf("rig_pathname", portPath);
+            SetConf("rig_pathname", normalizedPath);
 
             // Set serial parameters via conf tokens where available
             SetConf("serial_speed", baudRate.ToString());
@@ -137,18 +139,23 @@ public sealed class HamlibRig : IDisposable
             var result = HamlibNative.rig_set_conf(_rig, token, value);
             if (result != RigError.RIG_OK)
             {
-                _logger?.LogDebug("Failed to set {Name}={Value}: {Error}", name, value, GetErrorString(result));
+                _logger?.LogWarning("Failed to set {Name}={Value}: {Error}", name, value, GetErrorString(result));
+            }
+            else
+            {
+                _logger?.LogInformation("Set config {Name}={Value}", name, value);
             }
         }
         else
         {
-            _logger?.LogDebug("Config token not found: {Name}", name);
+            _logger?.LogWarning("Config token not found: {Name} (value was: {Value})", name, value);
         }
     }
 
     /// <summary>
     /// Open connection to the rig
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when rig_open fails with error details</exception>
     public bool Open()
     {
         ThrowIfDisposed();
@@ -160,8 +167,9 @@ public sealed class HamlibRig : IDisposable
             var result = HamlibNative.rig_open(_rig);
             if (result != RigError.RIG_OK)
             {
-                _logger?.LogError("Failed to open rig: {Error}", GetErrorString(result));
-                return false;
+                var errorMsg = GetErrorString(result);
+                _logger?.LogError("Failed to open rig: {Error} (code {Code})", errorMsg, result);
+                throw new InvalidOperationException($"Hamlib rig_open failed: {errorMsg} (error code {result})");
             }
 
             _isOpen = true;
@@ -491,6 +499,33 @@ public sealed class HamlibRig : IDisposable
         }
     }
 
+    /// <summary>
+    /// Normalize serial port path for the current platform
+    /// Windows COM ports need special handling for Hamlib
+    /// </summary>
+    private static string NormalizeSerialPortPath(string portPath)
+    {
+        if (string.IsNullOrEmpty(portPath))
+            return portPath;
+
+        // On Windows, normalize COM port paths
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // If it's already in \\.\COMx format, leave it alone
+            if (portPath.StartsWith(@"\\.\", StringComparison.OrdinalIgnoreCase))
+                return portPath;
+
+            // If it's COMx format, convert to \\.\COMx for compatibility
+            // This is required for COM ports >= 10, and works for all COM ports
+            if (portPath.StartsWith("COM", StringComparison.OrdinalIgnoreCase))
+            {
+                return @"\\.\" + portPath.ToUpperInvariant();
+            }
+        }
+
+        return portPath;
+    }
+
     private static string GetErrorString(int errorCode)
     {
         // Try rigerror2 first (Hamlib 4.5+), fall back to rigerror
@@ -694,25 +729,26 @@ public record RigCapabilities
     public int DefaultDataBits { get; init; }
     public int DefaultStopBits { get; init; }
     public bool IsNetworkOnly { get; init; }
+    public bool SupportsSerial { get; init; }
+    public bool SupportsNetwork { get; init; }
 
     /// <summary>
     /// Get capabilities for a specific rig model
     /// Note: This requires creating a temporary rig instance
     /// </summary>
-    public static RigCapabilities GetForModel(int modelId)
+    public static RigCapabilities GetForModel(int modelId, string? manufacturer = null, string? model = null)
     {
         var capsPtr = HamlibNative.rig_get_caps(modelId);
         if (capsPtr == IntPtr.Zero)
         {
-            return new RigCapabilities();
+            return new RigCapabilities { SupportsSerial = true, SupportsNetwork = false };
         }
 
-        // The rig_caps structure is complex - we need to create a rig instance
-        // to properly check capabilities
-        var isNetworkOnly = modelId == RigModel.RIG_MODEL_NETRIGCTL;
+        // Determine connection type support based on known models
+        var connectionTypes = RigConnectionTypeHelper.GetSupportedConnectionTypes(modelId, manufacturer, model);
 
-        // For network rigs, assume broad capability (actual caps known after connect)
-        if (isNetworkOnly)
+        // For network-only rigs, assume broad capability (actual caps known after connect)
+        if (connectionTypes.IsNetworkOnly)
         {
             return new RigCapabilities
             {
@@ -727,7 +763,9 @@ public record RigCapabilities
                 CanSendMorse = true,
                 DefaultDataBits = 8,
                 DefaultStopBits = 1,
-                IsNetworkOnly = true
+                IsNetworkOnly = true,
+                SupportsSerial = connectionTypes.SupportsSerial,
+                SupportsNetwork = connectionTypes.SupportsNetwork
             };
         }
 
@@ -747,7 +785,102 @@ public record RigCapabilities
             CanSendMorse = false, // Be conservative on morse
             DefaultDataBits = 8,
             DefaultStopBits = 1,
-            IsNetworkOnly = false
+            IsNetworkOnly = false,
+            SupportsSerial = connectionTypes.SupportsSerial,
+            SupportsNetwork = connectionTypes.SupportsNetwork
         };
+    }
+}
+
+/// <summary>
+/// Helper to determine supported connection types for rig models
+/// </summary>
+public static class RigConnectionTypeHelper
+{
+    /// <summary>
+    /// Known network-only rig model IDs
+    /// </summary>
+    private static readonly HashSet<int> NetworkOnlyModels = new()
+    {
+        RigModel.RIG_MODEL_NETRIGCTL, // 2 - NET rigctld
+        2036,  // FlexRadio 6xxx (Stable) - uses SmartSDR API
+        2037,  // FlexRadio 6xxx (Beta)
+        2038,  // FlexRadio 6xxx (Alpha)
+        2501,  // SDRPlay
+        2502,  // SDRPlay (Experimental)
+        // Apache Labs ANAN SDRs
+        2601,  // Apache Labs ANAN-10
+        2602,  // Apache Labs ANAN-100
+        2603,  // Apache Labs ANAN-100D
+        2604,  // Apache Labs ANAN-200D
+        2605,  // Apache Labs ANAN-7000DLE
+        2606,  // Apache Labs ANAN-8000DLE
+        // TRX-Manager network
+        2901,
+    };
+
+    /// <summary>
+    /// Known serial-only rig model IDs (most traditional rigs)
+    /// </summary>
+    private static readonly HashSet<int> SerialOnlyModels = new()
+    {
+        // Most traditional rigs are serial-only, but we default to serial+network
+        // to allow flexibility. Only explicitly mark those that MUST be serial.
+    };
+
+    /// <summary>
+    /// Manufacturer/model patterns that indicate network-only support
+    /// </summary>
+    private static readonly string[] NetworkOnlyPatterns = new[]
+    {
+        "FlexRadio",
+        "Flex 6",
+        "ANAN",
+        "Apache Labs",
+        "SDRPlay",
+        "PowerSDR",
+        "Thetis",
+        "piHPSDR",
+        "OpenHPSDR"
+    };
+
+    public record ConnectionTypeInfo(bool SupportsSerial, bool SupportsNetwork, bool IsNetworkOnly);
+
+    /// <summary>
+    /// Determine supported connection types for a rig model
+    /// </summary>
+    public static ConnectionTypeInfo GetSupportedConnectionTypes(int modelId, string? manufacturer = null, string? model = null)
+    {
+        // Check known network-only models
+        if (NetworkOnlyModels.Contains(modelId))
+        {
+            return new ConnectionTypeInfo(SupportsSerial: false, SupportsNetwork: true, IsNetworkOnly: true);
+        }
+
+        // Check model ID 2 (NET rigctld) explicitly
+        if (modelId == RigModel.RIG_MODEL_NETRIGCTL)
+        {
+            return new ConnectionTypeInfo(SupportsSerial: false, SupportsNetwork: true, IsNetworkOnly: true);
+        }
+
+        // Check known serial-only models
+        if (SerialOnlyModels.Contains(modelId))
+        {
+            return new ConnectionTypeInfo(SupportsSerial: true, SupportsNetwork: false, IsNetworkOnly: false);
+        }
+
+        // Check manufacturer/model name patterns
+        var fullName = $"{manufacturer} {model}".ToUpperInvariant();
+        foreach (var pattern in NetworkOnlyPatterns)
+        {
+            if (fullName.Contains(pattern.ToUpperInvariant()))
+            {
+                return new ConnectionTypeInfo(SupportsSerial: false, SupportsNetwork: true, IsNetworkOnly: true);
+            }
+        }
+
+        // Default: Most traditional rigs support serial, but we also allow network
+        // for cases like rigctld proxying
+        return new ConnectionTypeInfo(SupportsSerial: true, SupportsNetwork: true, IsNetworkOnly: false);
     }
 }

--- a/src/Log4YM.Server/Native/Hamlib/HamlibNative.cs
+++ b/src/Log4YM.Server/Native/Hamlib/HamlibNative.cs
@@ -672,3 +672,19 @@ public enum SerialParity
     Mark = 3,
     Space = 4
 }
+
+/// <summary>
+/// Hamlib rig port types
+/// </summary>
+public enum RigPortType
+{
+    None = 0,
+    Serial = 1,
+    Device = 2,      // Generic device (serial-like)
+    Network = 4,
+    Udp = 5,
+    Parallel = 6,
+    Usb = 7,
+    Gpio = 8,
+    Cm108 = 9
+}

--- a/src/Log4YM.Server/Program.cs
+++ b/src/Log4YM.Server/Program.cs
@@ -30,8 +30,12 @@ builder.Services.AddSwaggerGen(c =>
     c.SwaggerDoc("v1", new() { Title = "Log4YM API", Version = "v1" });
 });
 
-// Add SignalR
-builder.Services.AddSignalR();
+// Add SignalR with JSON enum string serialization
+builder.Services.AddSignalR()
+    .AddJsonProtocol(options =>
+    {
+        options.PayloadSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 
 // Add CORS
 builder.Services.AddCors(options =>

--- a/src/Log4YM.Web/src/api/signalr.ts
+++ b/src/Log4YM.Web/src/api/signalr.ts
@@ -318,6 +318,8 @@ export interface HamlibRigCapabilities {
   defaultDataBits: number;
   defaultStopBits: number;
   isNetworkOnly: boolean;
+  supportsSerial: boolean;
+  supportsNetwork: boolean;
 }
 
 export interface HamlibRigConfigDto {

--- a/src/Log4YM.Web/src/components/Header.tsx
+++ b/src/Log4YM.Web/src/components/Header.tsx
@@ -1,6 +1,11 @@
+import { Settings } from 'lucide-react';
+import { useSettingsStore } from '../store/settingsStore';
+
 export function Header() {
+  const { openSettings } = useSettingsStore();
+
   return (
-    <header className="h-14 bg-dark-800/90 backdrop-blur-xl border-b border-glass-100 flex items-center px-4">
+    <header className="h-14 bg-dark-800/90 backdrop-blur-xl border-b border-glass-100 flex items-center justify-between px-4">
       {/* Logo */}
       <div className="flex items-center gap-3">
         <div className="relative w-10 h-10">
@@ -27,6 +32,13 @@ export function Header() {
           </h1>
           <p className="text-[10px] text-orange-500/80 tracking-widest uppercase -mt-0.5">Hamradio Logging</p>
         </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <button onClick={openSettings} className="glass-button p-2" title="Settings">
+          <Settings className="w-4 h-4" />
+        </button>
       </div>
     </header>
   );

--- a/src/Log4YM.Web/src/plugins/RadioPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/RadioPlugin.tsx
@@ -124,6 +124,18 @@ export function RadioPlugin() {
     }
   }, [hamlibConfig.modelId, getHamlibRigCaps]);
 
+  // Auto-select connection type based on capabilities
+  useEffect(() => {
+    if (hamlibCaps) {
+      // If current selection is not supported, switch to supported type
+      if (hamlibConfig.connectionType === "Serial" && !hamlibCaps.supportsSerial && hamlibCaps.supportsNetwork) {
+        updateHamlibConfig({ connectionType: "Network" });
+      } else if (hamlibConfig.connectionType === "Network" && !hamlibCaps.supportsNetwork && hamlibCaps.supportsSerial) {
+        updateHamlibConfig({ connectionType: "Serial" });
+      }
+    }
+  }, [hamlibCaps, hamlibConfig.connectionType]);
+
   // Filter rigs by search term
   const filteredRigs = useMemo(() => {
     if (!rigSearch) return hamlibRigs.slice(0, 50); // Show first 50 by default
@@ -478,22 +490,23 @@ export function RadioPlugin() {
               <div className="flex gap-2">
                 <button
                   onClick={() => updateHamlibConfig({ connectionType: "Serial" })}
-                  disabled={hamlibCaps?.isNetworkOnly}
+                  disabled={hamlibCaps ? !hamlibCaps.supportsSerial : false}
                   className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
                     hamlibConfig.connectionType === "Serial"
                       ? "bg-orange-500/20 text-orange-400 border border-orange-500/30"
                       : "bg-dark-800 text-gray-400 border border-glass-100 hover:bg-dark-700"
-                  } disabled:opacity-50`}
+                  } disabled:opacity-50 disabled:cursor-not-allowed`}
                 >
                   Serial
                 </button>
                 <button
                   onClick={() => updateHamlibConfig({ connectionType: "Network" })}
+                  disabled={hamlibCaps ? !hamlibCaps.supportsNetwork : false}
                   className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
                     hamlibConfig.connectionType === "Network"
                       ? "bg-orange-500/20 text-orange-400 border border-orange-500/30"
                       : "bg-dark-800 text-gray-400 border border-glass-100 hover:bg-dark-700"
-                  }`}
+                  } disabled:opacity-50 disabled:cursor-not-allowed`}
                 >
                   Network
                 </button>


### PR DESCRIPTION
This pull request improves the handling and detection of radio connection types (serial vs. network) across both the backend and frontend, enhances logging for configuration and error reporting, and adds better platform compatibility for serial port paths. The changes also introduce more robust capability detection for Hamlib-supported radios and update the UI to reflect these capabilities.

**Backend: Enhanced capability detection and configuration**

* Added `SupportsSerial` and `SupportsNetwork` properties to `RigCapabilities` and related DTOs, with logic to detect these based on rig model, manufacturer, and model name, including a new `RigConnectionTypeHelper` for more accurate detection. [[1]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851R732-R751) [[2]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851L750-R886) [[3]](diffhunk://#diff-4299f944195b472068badf5ed4ab6d0cf908e6729bf54a8f9b25af6e05fafecdL516-R518) [[4]](diffhunk://#diff-6001d82dc5a3396637ff5563404f85e986df4ea1b502726a5dcac5fff5cb373fL440-R442) [[5]](diffhunk://#diff-8948722b939bff961c56238da65a47a3ef0474660bdd7f3d11be3b5d9f615103R321-R322)
* Improved serial port configuration to normalize Windows COM port paths for compatibility, and added detailed logging for serial, network, and PTT configuration steps. [[1]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851L62-R71) [[2]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851R502-R528) [[3]](diffhunk://#diff-54a7652efa772945df4b58e9517550d9e1828f14b769706fd72155b20ef07dfbR201-R203) [[4]](diffhunk://#diff-54a7652efa772945df4b58e9517550d9e1828f14b769706fd72155b20ef07dfbR215-R216) [[5]](diffhunk://#diff-54a7652efa772945df4b58e9517550d9e1828f14b769706fd72155b20ef07dfbR227-R234)
* Changed error handling: `Open()` now throws an exception with detailed error info instead of returning false, and logging for configuration errors is more informative. [[1]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851L140-R158) [[2]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851L163-R172)
* When returning default capabilities, ensures `SupportsSerial` and `SupportsNetwork` are set appropriately, and passes manufacturer/model info for more accurate detection. [[1]](diffhunk://#diff-54a7652efa772945df4b58e9517550d9e1828f14b769706fd72155b20ef07dfbL136-R140) [[2]](diffhunk://#diff-777f2bafed3f381ffc00a55059e4f3fcc3867f1d8fe6b4077b7a270605712851L730-R768)
* Added new `RigPortType` enum for future extensibility.

**Frontend: UI and UX improvements for connection type selection**

* Updated the SignalR API and frontend types to include `supportsSerial` and `supportsNetwork` for each rig capability.
* The connection type selector in the radio plugin now disables unsupported options and auto-switches to a supported type if the current selection is not available for the chosen rig. [[1]](diffhunk://#diff-8e44547ca5825718c3c2fd06d325c976e82617e7a6a85e5f4e0ff2412e360abdR127-R138) [[2]](diffhunk://#diff-8e44547ca5825718c3c2fd06d325c976e82617e7a6a85e5f4e0ff2412e360abdL481-R509)
* Added a settings button to the header for easier access to configuration. [[1]](diffhunk://#diff-b45a3aaf6d48e7e5f92ba253bbd464a530eeafcf1693f3bd0341c8ec55ee82e3R1-R8) [[2]](diffhunk://#diff-b45a3aaf6d48e7e5f92ba253bbd464a530eeafcf1693f3bd0341c8ec55ee82e3R36-R42)

**Other improvements**

* SignalR now serializes enums as strings in JSON payloads for improved interoperability.
* Added additional logging when creating rig instances and during configuration for better traceability and debugging.

These changes together make the application more robust, user-friendly, and compatible with a wider range of radio hardware and connection scenarios.