### PR TITLE
feat(map): Add distance-based flyTo animation for 2D map and 3D globe

### DIFF
--- a/src/Log4YM.Web/src/utils/maidenhead.ts
+++ b/src/Log4YM.Web/src/utils/maidenhead.ts
@@ -106,17 +106,35 @@ export function calculateDistance(lat1: number, lon1: number, lat2: number, lon2
 export function calculateBearing(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const toRad = Math.PI / 180;
   const toDeg = 180 / Math.PI;
-  
+
   const dLon = (lon2 - lon1) * toRad;
   const lat1Rad = lat1 * toRad;
   const lat2Rad = lat2 * toRad;
-  
+
   const y = Math.sin(dLon) * Math.cos(lat2Rad);
   const x = Math.cos(lat1Rad) * Math.sin(lat2Rad) -
       Math.sin(lat1Rad) * Math.cos(lat2Rad) * Math.cos(dLon);
-  
+
   let bearing = Math.atan2(y, x) * toDeg;
   bearing = (bearing + 360) % 360;
-  
+
   return bearing;
+}
+
+/**
+ * Get animation duration in seconds based on distance between two points
+ * Uses distance thresholds for smooth visual experience:
+ * - < 500 km: 2 seconds (same country/nearby)
+ * - 500-2000 km: 3 seconds (regional)
+ * - 2000-5000 km: 4 seconds (continental)
+ * - > 5000 km: 5 seconds (intercontinental)
+ *
+ * @param distanceKm Distance in kilometers
+ * @returns Animation duration in seconds
+ */
+export function getAnimationDuration(distanceKm: number): number {
+  if (distanceKm < 500) return 2;
+  if (distanceKm < 2000) return 3;
+  if (distanceKm < 5000) return 4;
+  return 5;
 }


### PR DESCRIPTION
## Summary

- Implement smooth camera animations when navigating between active callsigns for both 2D Leaflet map and 3D globe
- Add `getAnimationDuration()` utility function with distance-based thresholds matching the reference documentation in #32
- Both maps now automatically fly to focused callsign locations with appropriate animation duration

## Implementation Details

### Distance-Based Animation Durations
| Distance | Duration | Use Case |
|----------|----------|----------|
| < 500 km | 2 seconds | Same country/nearby |
| 500-2000 km | 3 seconds | Regional |
| 2000-5000 km | 4 seconds | Continental |
| > 5000 km | 5 seconds | Intercontinental |

### 2D Map (Leaflet)
- Uses native `flyTo()` method with zoom level 5 for target focus
- `easeLinearity: 0.1` for smooth curved motion
- Tracks previous target coordinates to calculate animation duration

### 3D Globe (globe.gl)
- Custom camera interpolation using `requestAnimationFrame`
- `easeInOutCubic` easing function for smooth curved motion
- Handles date line crossing for shortest path
- Altitude adjustment to zoom level 2.0 when focusing on target

## Test plan

- [ ] Focus on a callsign nearby (< 500km) - verify 2 second animation
- [ ] Focus on a callsign regionally (500-2000km) - verify 3 second animation
- [ ] Focus on a callsign continentally (2000-5000km) - verify 4 second animation
- [ ] Focus on a callsign intercontinentally (> 5000km) - verify 5 second animation
- [ ] Verify 2D map and 3D globe both animate smoothly
- [ ] Verify date line crossing works correctly on 3D globe

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)