### PR TITLE
feat(ui): restyle to OpenHamClock instrument panel aesthetic

### DIFF
--- a/src/Log4YM.Web/index.html
+++ b/src/Log4YM.Web/index.html
@@ -4,12 +4,15 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/radio.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0a0a0f" />
+    <meta name="theme-color" content="#0a0e14" />
     <title>Log4YM - Amateur Radio Logging</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <style>
       /* Prevent flash of unstyled content */
       html {
-        background-color: #0a0a0f;
+        background-color: #0a0e14;
       }
     </style>
   </head>

--- a/src/Log4YM.Web/src/App.tsx
+++ b/src/Log4YM.Web/src/App.tsx
@@ -214,7 +214,7 @@ export function App() {
 
     if (plugin) {
       renderValues.leading = (
-        <span className="mr-2 text-accent-primary">{plugin.icon}</span>
+        <span className="mr-2 text-accent-secondary">{plugin.icon}</span>
       );
     }
   }, []);
@@ -245,7 +245,7 @@ export function App() {
   }, [resetLayoutStore]);
 
   return (
-    <div className="h-screen flex flex-col bg-dark-900 text-gray-100">
+    <div className="h-screen flex flex-col bg-dark-900 text-gray-100 crt-scanlines relative">
       <main className="flex-1 relative overflow-hidden">
         <Layout
           ref={layoutRef}
@@ -255,26 +255,25 @@ export function App() {
           onRenderTab={onRenderTab}
           onRenderTabSet={onRenderTabSet}
           classNameMapper={(className) => {
-            // Apply custom dark theme classes
             return className;
           }}
         />
 
         {/* Panel Picker Modal */}
         {showPanelPicker && (
-          <div className="absolute inset-0 bg-dark-900/80 backdrop-blur-sm flex items-center justify-center z-50">
+          <div className="absolute inset-0 bg-dark-900/85 backdrop-blur-sm flex items-center justify-center z-50">
             <div className="glass-panel w-96 animate-fade-in">
               <div className="flex items-center justify-between px-4 py-3 border-b border-glass-100">
                 <div className="flex items-center gap-2">
-                  <LayoutGrid className="w-5 h-5 text-accent-primary" />
-                  <h3 className="font-semibold">Add Panel</h3>
+                  <LayoutGrid className="w-5 h-5 text-accent-secondary" />
+                  <h3 className="font-semibold text-accent-success font-ui text-sm tracking-wide uppercase">Add Panel</h3>
                 </div>
                 <button
                   onClick={() => {
                     setShowPanelPicker(false);
                     setTargetTabSetId(null);
                   }}
-                  className="p-1 hover:bg-dark-600 rounded transition-colors"
+                  className="p-1 hover:bg-dark-600 rounded transition-colors text-dark-300 hover:text-accent-danger"
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -287,7 +286,7 @@ export function App() {
 
                   if (availablePlugins.length === 0) {
                     return (
-                      <div className="col-span-2 text-center py-4 text-gray-500">
+                      <div className="col-span-2 text-center py-4 text-dark-300">
                         All panels have been added to the layout
                       </div>
                     );
@@ -297,10 +296,10 @@ export function App() {
                     <button
                       key={id}
                       onClick={() => handleAddPanel(id)}
-                      className="glass-button flex flex-col items-center gap-2 p-4 hover:border-accent-primary/50"
+                      className="glass-button flex flex-col items-center gap-2 p-4 hover:border-accent-secondary/40"
                     >
-                      <span className="text-accent-primary">{plugin.icon}</span>
-                      <span className="text-sm">{plugin.name}</span>
+                      <span className="text-accent-secondary">{plugin.icon}</span>
+                      <span className="text-sm font-ui">{plugin.name}</span>
                     </button>
                   ));
                 })()}
@@ -309,7 +308,7 @@ export function App() {
               <div className="px-4 py-3 border-t border-glass-100">
                 <button
                   onClick={handleResetLayout}
-                  className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+                  className="text-sm text-dark-300 hover:text-accent-danger transition-colors font-ui"
                 >
                   Reset to default layout
                 </button>

--- a/src/Log4YM.Web/src/components/ConnectionOverlay.tsx
+++ b/src/Log4YM.Web/src/components/ConnectionOverlay.tsx
@@ -8,8 +8,6 @@ export function ConnectionOverlay() {
   const [isManualReconnecting, setIsManualReconnecting] = useState(false);
 
   // Only show overlay when NOT fully connected
-  // Show during: disconnected, reconnecting, rehydrating
-  // Hide during: connected, connecting (initial load handled by app)
   if (connectionState === 'connected' || connectionState === 'connecting') {
     return null;
   }
@@ -34,11 +32,11 @@ export function ConnectionOverlay() {
         <div className="flex justify-center mb-4">
           {isRehydrating ? (
             <div className="relative">
-              <Database className="w-16 h-16 text-accent-info animate-pulse" />
+              <Database className="w-16 h-16 text-accent-secondary animate-pulse" />
             </div>
           ) : showSpinner ? (
             <div className="relative">
-              <Loader2 className="w-16 h-16 text-accent-warning animate-spin" />
+              <Loader2 className="w-16 h-16 text-accent-primary animate-spin" />
             </div>
           ) : (
             <div className="w-16 h-16 rounded-full bg-accent-danger/20 flex items-center justify-center">
@@ -47,11 +45,11 @@ export function ConnectionOverlay() {
           )}
         </div>
 
-        <h2 className="text-xl font-bold text-white mb-2">
+        <h2 className="text-xl font-bold text-accent-primary mb-2 font-display tracking-wide">
           {isRehydrating ? 'Loading Data...' : isReconnecting ? 'Reconnecting...' : 'Connection Lost'}
         </h2>
 
-        <p className="text-gray-400 mb-4">
+        <p className="text-dark-300 mb-4 font-ui">
           {isRehydrating ? (
             <>
               Restoring application state from server.
@@ -63,7 +61,7 @@ export function ConnectionOverlay() {
             <>
               Attempting to reconnect to the server
               {reconnectAttempt > 0 && (
-                <span className="block text-sm mt-1">
+                <span className="block text-sm mt-1 font-mono text-accent-secondary">
                   Attempt {reconnectAttempt}
                 </span>
               )}
@@ -77,7 +75,7 @@ export function ConnectionOverlay() {
           <button
             onClick={handleReconnect}
             disabled={isManualReconnecting}
-            className="glass-button px-6 py-2 flex items-center gap-2 mx-auto hover:border-accent-primary/50 disabled:opacity-50"
+            className="glass-button px-6 py-2 flex items-center gap-2 mx-auto hover:border-accent-secondary/40 disabled:opacity-50"
           >
             <RefreshCw className="w-4 h-4" />
             <span>Reconnect Now</span>
@@ -86,10 +84,10 @@ export function ConnectionOverlay() {
 
         {isDisconnected && (
           <div className="mt-6 pt-4 border-t border-glass-100">
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-dark-300 font-ui">
               The application will automatically retry connection with exponential backoff.
               {reconnectAttempt > 0 && (
-                <span className="block mt-1">
+                <span className="block mt-1 font-mono text-accent-secondary">
                   Next retry in up to {Math.min(Math.pow(2, reconnectAttempt), 30)} seconds
                 </span>
               )}

--- a/src/Log4YM.Web/src/components/GlassPanel.tsx
+++ b/src/Log4YM.Web/src/components/GlassPanel.tsx
@@ -14,8 +14,8 @@ export function GlassPanel({ children, className = '', title, icon, actions }: G
       {(title || actions) && (
         <div className="flex items-center justify-between px-4 py-3 border-b border-glass-100">
           <div className="flex items-center gap-2">
-            {icon && <span className="text-accent-primary">{icon}</span>}
-            {title && <h3 className="font-semibold text-gray-100">{title}</h3>}
+            {icon && <span className="text-accent-secondary">{icon}</span>}
+            {title && <h3 className="font-semibold text-accent-success font-ui text-sm tracking-wide uppercase">{title}</h3>}
           </div>
           {actions && <div className="flex items-center gap-2">{actions}</div>}
         </div>

--- a/src/Log4YM.Web/src/components/SettingsPanel.tsx
+++ b/src/Log4YM.Web/src/components/SettingsPanel.tsx
@@ -83,14 +83,14 @@ function StationSettingsSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">Station Information</h3>
-        <p className="text-sm text-gray-500">Configure your station callsign and location details.</p>
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">Station Information</h3>
+        <p className="text-sm text-dark-300">Configure your station callsign and location details.</p>
       </div>
 
       <div className="grid grid-cols-2 gap-4">
         {/* Callsign */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             <Radio className="w-4 h-4 text-accent-primary" />
             Callsign
           </label>
@@ -105,7 +105,7 @@ function StationSettingsSection() {
 
         {/* Operator Name */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             <User className="w-4 h-4 text-accent-primary" />
             Operator Name
           </label>
@@ -120,7 +120,7 @@ function StationSettingsSection() {
 
         {/* Grid Square */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             <MapPin className="w-4 h-4 text-accent-primary" />
             Grid Square (Maidenhead)
           </label>
@@ -136,7 +136,7 @@ function StationSettingsSection() {
 
         {/* City */}
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-300">City</label>
+          <label className="text-sm font-medium font-ui text-dark-200">City</label>
           <input
             type="text"
             value={station.city}
@@ -148,7 +148,7 @@ function StationSettingsSection() {
 
         {/* Country */}
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-300">Country</label>
+          <label className="text-sm font-medium font-ui text-dark-200">Country</label>
           <input
             type="text"
             value={station.country}
@@ -161,10 +161,10 @@ function StationSettingsSection() {
 
       {/* Coordinates */}
       <div className="border-t border-glass-100 pt-4">
-        <h4 className="text-sm font-medium text-gray-300 mb-3">Coordinates (Optional)</h4>
+        <h4 className="text-sm font-medium font-ui text-dark-200 mb-3">Coordinates (Optional)</h4>
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
-            <label className="text-sm text-gray-400">Latitude</label>
+            <label className="text-sm font-ui text-dark-300">Latitude</label>
             <input
               type="number"
               step="0.0001"
@@ -179,7 +179,7 @@ function StationSettingsSection() {
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm text-gray-400">Longitude</label>
+            <label className="text-sm font-ui text-dark-300">Longitude</label>
             <input
               type="number"
               step="0.0001"
@@ -245,8 +245,8 @@ function QrzSettingsSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">QRZ.com Integration</h3>
-        <p className="text-sm text-gray-500">
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">QRZ.com Integration</h3>
+        <p className="text-sm text-dark-300">
           Configure your QRZ.com credentials for callsign lookups and log uploads.
         </p>
       </div>
@@ -254,8 +254,8 @@ function QrzSettingsSection() {
       {/* Enable toggle */}
       <div className="flex items-center justify-between p-4 bg-dark-700/50 rounded-lg border border-glass-100">
         <div>
-          <p className="font-medium text-gray-200">Enable QRZ Lookups</p>
-          <p className="text-sm text-gray-500">Use QRZ.com for callsign information</p>
+          <p className="font-medium font-ui text-dark-200">Enable QRZ Lookups</p>
+          <p className="text-sm text-dark-300">Use QRZ.com for callsign information</p>
         </div>
         <button
           onClick={() => updateQrzSettings({ enabled: !qrz.enabled })}
@@ -275,8 +275,8 @@ function QrzSettingsSection() {
       {hasXmlSubscription !== null && (
         <div className={`flex items-center gap-2 p-3 rounded-lg border ${
           hasXmlSubscription
-            ? 'bg-green-500/10 border-green-500/30 text-green-400'
-            : 'bg-yellow-500/10 border-yellow-500/30 text-yellow-400'
+            ? 'bg-accent-success/10 border-accent-success/30 text-accent-success'
+            : 'bg-accent-primary/10 border-accent-primary/30 text-accent-primary'
         }`}>
           {hasXmlSubscription ? (
             <>
@@ -295,7 +295,7 @@ function QrzSettingsSection() {
       {/* Credentials */}
       <div className={`space-y-4 ${!qrz.enabled ? 'opacity-50 pointer-events-none' : ''}`}>
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             <User className="w-4 h-4 text-accent-primary" />
             QRZ Username (Callsign)
           </label>
@@ -310,7 +310,7 @@ function QrzSettingsSection() {
         </div>
 
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             <Key className="w-4 h-4 text-accent-primary" />
             QRZ Password
           </label>
@@ -326,21 +326,21 @@ function QrzSettingsSection() {
             <button
               type="button"
               onClick={() => setShowPassword(!showPassword)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-300"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-dark-300 hover:text-dark-200"
             >
               {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </button>
           </div>
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-dark-300">
             Required for callsign lookups (requires XML subscription on QRZ.com).
           </p>
         </div>
 
         {/* API Key for Logbook */}
         <div className="pt-4 border-t border-glass-100">
-          <h4 className="text-sm font-medium text-gray-300 mb-3">QRZ Logbook Integration</h4>
+          <h4 className="text-sm font-medium font-ui text-dark-200 mb-3">QRZ Logbook Integration</h4>
           <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+            <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
               <Key className="w-4 h-4 text-accent-info" />
               Logbook API Key
             </label>
@@ -356,12 +356,12 @@ function QrzSettingsSection() {
               <button
                 type="button"
                 onClick={() => setShowApiKey(!showApiKey)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-300"
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-dark-300 hover:text-dark-200"
               >
                 {showApiKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
               </button>
             </div>
-            <p className="text-xs text-gray-600">
+            <p className="text-xs text-dark-300">
               Get your API key from{' '}
               <a
                 href="https://logbook.qrz.com/logbook"
@@ -400,7 +400,7 @@ function QrzSettingsSection() {
             </span>
           </button>
           {testMessage && (
-            <span className={`text-sm ${testStatus === 'success' ? 'text-green-400' : 'text-red-400'}`}>
+            <span className={`text-sm ${testStatus === 'success' ? 'text-accent-success' : 'text-accent-danger'}`}>
               {testMessage}
             </span>
           )}
@@ -418,8 +418,8 @@ function RotatorSettingsSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">Rotator Control</h3>
-        <p className="text-sm text-gray-500">
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">Rotator Control</h3>
+        <p className="text-sm text-dark-300">
           Configure connection to hamlib rotctld for antenna rotator control.
         </p>
       </div>
@@ -430,11 +430,11 @@ function RotatorSettingsSection() {
           {rotator.enabled ? (
             <Wifi className="w-5 h-5 text-accent-success" />
           ) : (
-            <WifiOff className="w-5 h-5 text-gray-500" />
+            <WifiOff className="w-5 h-5 text-dark-300" />
           )}
           <div>
-            <p className="font-medium text-gray-200">Enable Rotator Control</p>
-            <p className="text-sm text-gray-500">Connect to rotctld TCP server</p>
+            <p className="font-medium font-ui text-dark-200">Enable Rotator Control</p>
+            <p className="text-sm text-dark-300">Connect to rotctld TCP server</p>
           </div>
         </div>
         <button
@@ -456,7 +456,7 @@ function RotatorSettingsSection() {
         <div className="grid grid-cols-2 gap-4">
           {/* IP Address */}
           <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+            <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
               <Globe className="w-4 h-4 text-accent-primary" />
               IP Address
             </label>
@@ -472,7 +472,7 @@ function RotatorSettingsSection() {
 
           {/* Port */}
           <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+            <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
               <Compass className="w-4 h-4 text-accent-primary" />
               Port
             </label>
@@ -489,7 +489,7 @@ function RotatorSettingsSection() {
 
         {/* Polling Interval */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             Polling Interval (ms)
           </label>
           <input
@@ -503,14 +503,14 @@ function RotatorSettingsSection() {
             className="glass-input w-48 font-mono"
             disabled={!rotator.enabled}
           />
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-dark-300">
             How often to poll the rotator for position updates (100-5000ms)
           </p>
         </div>
 
         {/* Rotator ID */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             Rotator ID
           </label>
           <input
@@ -521,7 +521,7 @@ function RotatorSettingsSection() {
             className="glass-input w-48 font-mono"
             disabled={!rotator.enabled}
           />
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-dark-300">
             Identifier for this rotator (useful if you have multiple rotators)
           </p>
         </div>
@@ -529,7 +529,7 @@ function RotatorSettingsSection() {
 
       {/* Help text */}
       <div className="pt-4 border-t border-glass-100">
-        <p className="text-xs text-gray-600">
+        <p className="text-xs text-dark-300">
           The rotator service connects to hamlib's rotctld daemon via TCP. Make sure rotctld is
           running and accessible at the configured address. Default port for rotctld is 4533.
         </p>
@@ -580,8 +580,8 @@ function DatabaseSettingsSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">Database Connection</h3>
-        <p className="text-sm text-gray-500">
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">Database Connection</h3>
+        <p className="text-sm text-dark-300">
           Configure your MongoDB connection for QSO and settings storage.
         </p>
       </div>
@@ -590,25 +590,25 @@ function DatabaseSettingsSection() {
       <div
         className={`p-4 rounded-lg border ${
           status?.isConnected
-            ? 'bg-green-500/10 border-green-500/30'
-            : 'bg-red-500/10 border-red-500/30'
+            ? 'bg-accent-success/10 border-accent-success/30'
+            : 'bg-accent-danger/10 border-accent-danger/30'
         }`}
       >
         <div className="flex items-center gap-3">
           {status?.isConnected ? (
-            <CheckCircle className="w-5 h-5 text-green-400" />
+            <CheckCircle className="w-5 h-5 text-accent-success" />
           ) : (
-            <AlertCircle className="w-5 h-5 text-red-400" />
+            <AlertCircle className="w-5 h-5 text-accent-danger" />
           )}
           <div>
-            <p className={`font-medium ${status?.isConnected ? 'text-green-400' : 'text-red-400'}`}>
+            <p className={`font-medium ${status?.isConnected ? 'text-accent-success' : 'text-accent-danger'}`}>
               {status?.isConnected ? 'Connected' : 'Not Connected'}
             </p>
             {status?.databaseName && (
-              <p className="text-sm text-gray-400">Database: {status.databaseName}</p>
+              <p className="text-sm text-dark-300">Database: {status.databaseName}</p>
             )}
             {status?.configuredAt && (
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-dark-300">
                 Configured: {new Date(status.configuredAt).toLocaleString()}
               </p>
             )}
@@ -630,7 +630,7 @@ function DatabaseSettingsSection() {
       {/* Connection String Input */}
       <div className="space-y-4">
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             <Server className="w-4 h-4 text-accent-primary" />
             MongoDB Connection String
           </label>
@@ -648,19 +648,19 @@ function DatabaseSettingsSection() {
             <button
               type="button"
               onClick={() => setShowConnectionString(!showConnectionString)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-300"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-dark-300 hover:text-dark-200"
             >
               {showConnectionString ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </button>
           </div>
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-dark-300">
             Your connection string is stored locally and never sent anywhere except MongoDB.
           </p>
         </div>
 
         {/* Database Name Input */}
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-300">Database Name</label>
+          <label className="text-sm font-medium font-ui text-dark-200">Database Name</label>
           <input
             type="text"
             value={databaseName}
@@ -671,7 +671,7 @@ function DatabaseSettingsSection() {
             placeholder="Log4YM"
             className="glass-input w-full font-mono"
           />
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-dark-300">
             The database will be created automatically if it doesn't exist.
           </p>
         </div>
@@ -682,22 +682,22 @@ function DatabaseSettingsSection() {
         <div
           className={`p-4 rounded-lg border ${
             testResult.success
-              ? 'bg-green-500/10 border-green-500/30'
-              : 'bg-red-500/10 border-red-500/30'
+              ? 'bg-accent-success/10 border-accent-success/30'
+              : 'bg-accent-danger/10 border-accent-danger/30'
           }`}
         >
           <div className="flex items-start gap-3">
             {testResult.success ? (
-              <CheckCircle className="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" />
+              <CheckCircle className="w-5 h-5 text-accent-success flex-shrink-0 mt-0.5" />
             ) : (
-              <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+              <AlertCircle className="w-5 h-5 text-accent-danger flex-shrink-0 mt-0.5" />
             )}
             <div>
-              <p className={`font-medium ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+              <p className={`font-medium ${testResult.success ? 'text-accent-success' : 'text-accent-danger'}`}>
                 {testResult.message}
               </p>
               {testResult.serverInfo && (
-                <p className="text-sm text-gray-400 mt-1">
+                <p className="text-sm text-dark-300 mt-1">
                   Found {testResult.serverInfo.databaseCount} database(s) on server
                 </p>
               )}
@@ -708,10 +708,10 @@ function DatabaseSettingsSection() {
 
       {/* Error Display */}
       {error && (
-        <div className="p-4 rounded-lg border bg-red-500/10 border-red-500/30">
+        <div className="p-4 rounded-lg border bg-accent-danger/10 border-accent-danger/30">
           <div className="flex items-start gap-3">
-            <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
-            <p className="text-red-400">{error}</p>
+            <AlertCircle className="w-5 h-5 text-accent-danger flex-shrink-0 mt-0.5" />
+            <p className="text-accent-danger">{error}</p>
           </div>
         </div>
       )}
@@ -756,7 +756,7 @@ function DatabaseSettingsSection() {
 
       {/* Info */}
       <div className="pt-4 border-t border-glass-100">
-        <p className="text-xs text-gray-600">
+        <p className="text-xs text-dark-300">
           Log4YM uses MongoDB to store your QSOs, settings, and layout preferences. You can use a
           free MongoDB Atlas cluster or a local MongoDB installation. Configuration is stored
           locally on your device.
@@ -774,13 +774,13 @@ function AppearanceSettingsSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">Appearance</h3>
-        <p className="text-sm text-gray-500">Customize the look and feel of the application.</p>
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">Appearance</h3>
+        <p className="text-sm text-dark-300">Customize the look and feel of the application.</p>
       </div>
 
       {/* Theme selection */}
       <div className="space-y-3">
-        <label className="text-sm font-medium text-gray-300">Theme</label>
+        <label className="text-sm font-medium font-ui text-dark-200">Theme</label>
         <div className="grid grid-cols-3 gap-3">
           {(['dark', 'light', 'system'] as const).map((theme) => (
             <button
@@ -796,14 +796,14 @@ function AppearanceSettingsSection() {
             </button>
           ))}
         </div>
-        <p className="text-xs text-gray-600">Currently only dark theme is available.</p>
+        <p className="text-xs text-dark-300">Currently only dark theme is available.</p>
       </div>
 
       {/* Compact mode toggle */}
       <div className="flex items-center justify-between p-4 bg-dark-700/50 rounded-lg border border-glass-100">
         <div>
-          <p className="font-medium text-gray-200">Compact Mode</p>
-          <p className="text-sm text-gray-500">Use smaller spacing and fonts</p>
+          <p className="font-medium font-ui text-dark-200">Compact Mode</p>
+          <p className="text-sm text-dark-300">Use smaller spacing and fonts</p>
         </div>
         <button
           onClick={() => updateAppearanceSettings({ compactMode: !appearance.compactMode })}
@@ -830,14 +830,14 @@ function HeaderSettingsSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">Header Bar Settings</h3>
-        <p className="text-sm text-gray-500">Customize the header bar display with space weather indices and time formats.</p>
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">Header Bar Settings</h3>
+        <p className="text-sm text-dark-300">Customize the header bar display with space weather indices and time formats.</p>
       </div>
 
       <div className="space-y-4">
         {/* Time Format */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             Time Format (Local)
           </label>
           <div className="flex gap-2">
@@ -846,7 +846,7 @@ function HeaderSettingsSection() {
               className={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
                 header.timeFormat === '12h'
                   ? 'bg-accent-primary/10 border-accent-primary text-accent-primary'
-                  : 'bg-dark-700/50 border-glass-100 text-gray-400 hover:bg-dark-700'
+                  : 'bg-dark-700/50 border-glass-100 text-dark-300 hover:bg-dark-700'
               }`}
             >
               12-Hour
@@ -856,18 +856,18 @@ function HeaderSettingsSection() {
               className={`flex-1 px-4 py-2 rounded-lg border transition-colors ${
                 header.timeFormat === '24h'
                   ? 'bg-accent-primary/10 border-accent-primary text-accent-primary'
-                  : 'bg-dark-700/50 border-glass-100 text-gray-400 hover:bg-dark-700'
+                  : 'bg-dark-700/50 border-glass-100 text-dark-300 hover:bg-dark-700'
               }`}
             >
               24-Hour
             </button>
           </div>
-          <p className="text-xs text-gray-500">You can also click the local time in the header to toggle formats.</p>
+          <p className="text-xs text-dark-300">You can also click the local time in the header to toggle formats.</p>
         </div>
 
         {/* Size Multiplier */}
         <div className="space-y-2">
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
             Header Size
           </label>
           <div className="grid grid-cols-4 gap-2">
@@ -878,14 +878,14 @@ function HeaderSettingsSection() {
                 className={`px-4 py-2 rounded-lg border transition-colors ${
                   header.sizeMultiplier === size
                     ? 'bg-accent-primary/10 border-accent-primary text-accent-primary'
-                    : 'bg-dark-700/50 border-glass-100 text-gray-400 hover:bg-dark-700'
+                    : 'bg-dark-700/50 border-glass-100 text-dark-300 hover:bg-dark-700'
                 }`}
               >
                 {size === 1.0 ? 'Normal' : `${size}x`}
               </button>
             ))}
           </div>
-          <p className="text-xs text-gray-500">Adjust the size of text and spacing in the header bar.</p>
+          <p className="text-xs text-dark-300">Adjust the size of text and spacing in the header bar.</p>
         </div>
 
         {/* Show Weather */}
@@ -893,8 +893,8 @@ function HeaderSettingsSection() {
           <div className="flex items-center gap-3">
             <Globe className="w-5 h-5 text-accent-primary" />
             <div>
-              <div className="font-medium text-gray-100">Show Weather</div>
-              <div className="text-sm text-gray-500">Display current weather in header (requires station coordinates)</div>
+              <div className="font-medium font-ui text-dark-200">Show Weather</div>
+              <div className="text-sm text-dark-300">Display current weather in header (requires station coordinates)</div>
             </div>
           </div>
           <input
@@ -907,20 +907,20 @@ function HeaderSettingsSection() {
 
         {/* Info Box */}
         <div className="p-4 bg-accent-primary/5 border border-accent-primary/20 rounded-lg">
-          <h4 className="font-medium text-accent-primary mb-2 flex items-center gap-2">
+          <h4 className="font-medium font-ui text-accent-primary mb-2 flex items-center gap-2">
             <Info className="w-4 h-4" />
             About the Header Bar
           </h4>
-          <div className="text-sm text-gray-400 space-y-2">
+          <div className="text-sm text-dark-300 space-y-2">
             <p>
               The header bar displays essential operating information inspired by OpenHamClock:
             </p>
             <ul className="list-disc list-inside space-y-1 ml-2">
-              <li><strong className="text-cyan-400">UTC Time</strong>: Essential for logging (always 24-hour format)</li>
-              <li><strong className="text-amber-400">Local Time</strong>: Your system time (clickable to toggle format)</li>
-              <li><strong className="text-amber-400">SFI</strong>: Solar Flux Index (higher is better for HF)</li>
-              <li><strong className="text-green-500">K-Index</strong>: Geomagnetic activity (turns <span className="text-red-500">red</span> when ≥4)</li>
-              <li><strong className="text-cyan-400">SSN</strong>: Sunspot Number (indicates solar activity)</li>
+              <li><strong className="text-accent-secondary">UTC Time</strong>: Essential for logging (always 24-hour format)</li>
+              <li><strong className="text-accent-primary">Local Time</strong>: Your system time (clickable to toggle format)</li>
+              <li><strong className="text-accent-primary">SFI</strong>: Solar Flux Index (higher is better for HF)</li>
+              <li><strong className="text-accent-success">K-Index</strong>: Geomagnetic activity (turns <span className="text-accent-danger">red</span> when ≥4)</li>
+              <li><strong className="text-accent-secondary">SSN</strong>: Sunspot Number (indicates solar activity)</li>
             </ul>
             <p className="pt-2 text-xs">
               Space weather data refreshes every 15 minutes. Weather data requires latitude/longitude in Station settings.
@@ -937,33 +937,33 @@ function AboutSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-100 mb-1">About Log4YM</h3>
-        <p className="text-sm text-gray-500">Version and application information.</p>
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">About Log4YM</h3>
+        <p className="text-sm text-dark-300">Version and application information.</p>
       </div>
 
       <div className="space-y-4">
         <div className="p-4 bg-dark-700/50 rounded-lg border border-glass-100">
           <div className="flex items-center gap-4">
-            <div className="w-16 h-16 bg-orange-500/20 rounded-lg flex items-center justify-center">
-              <Radio className="w-8 h-8 text-orange-500" />
+            <div className="w-16 h-16 bg-accent-primary/20 rounded-lg flex items-center justify-center">
+              <Radio className="w-8 h-8 text-accent-primary" />
             </div>
             <div>
-              <h4 className="text-xl font-bold text-orange-500">LOG4YM</h4>
-              <p className="text-sm text-gray-400">Ham Radio Logging Software</p>
-              <p className="text-xs text-gray-600 mt-1">Version 0.1.0 (Alpha)</p>
+              <h4 className="text-xl font-bold font-display text-accent-primary">LOG4YM</h4>
+              <p className="text-sm text-dark-300">Ham Radio Logging Software</p>
+              <p className="text-xs text-dark-300 mt-1">Version 0.1.0 (Alpha)</p>
             </div>
           </div>
         </div>
 
-        <div className="space-y-2 text-sm text-gray-400">
+        <div className="space-y-2 text-sm text-dark-300">
           <p>
-            <strong className="text-gray-300">Author:</strong> Brian Keating (EI6LF)
+            <strong className="text-dark-200">Author:</strong> Brian Keating (EI6LF)
           </p>
           <p>
-            <strong className="text-gray-300">License:</strong> MIT
+            <strong className="text-dark-200">License:</strong> MIT
           </p>
           <p>
-            <strong className="text-gray-300">Website:</strong>{' '}
+            <strong className="text-dark-200">Website:</strong>{' '}
             <a href="https://github.com/brianbruff/Log4YM" className="text-accent-primary hover:underline">
               github.com/brianbruff/Log4YM
             </a>
@@ -971,7 +971,7 @@ function AboutSection() {
         </div>
 
         <div className="pt-4 border-t border-glass-100">
-          <p className="text-xs text-gray-600">
+          <p className="text-xs text-dark-300">
             Log4YM is a modern ham radio logging application designed for amateur radio operators.
             It features real-time DX cluster integration, rotator control, and QSO logging.
           </p>
@@ -1038,7 +1038,7 @@ export function SettingsPanel() {
           <div className="p-4 border-b border-glass-100">
             <div className="flex items-center gap-3">
               <Settings className="w-6 h-6 text-accent-primary" />
-              <h2 className="text-lg font-semibold">Settings</h2>
+              <h2 className="text-lg font-semibold font-display">Settings</h2>
             </div>
           </div>
 
@@ -1051,15 +1051,15 @@ export function SettingsPanel() {
                 className={`w-full flex items-center gap-3 px-3 py-3 rounded-lg text-left transition-all ${
                   activeSection === section.id
                     ? 'bg-accent-primary/10 text-accent-primary border border-accent-primary/30'
-                    : 'hover:bg-dark-700 text-gray-400 hover:text-gray-200 border border-transparent'
+                    : 'hover:bg-dark-700 text-dark-300 hover:text-dark-200 border border-transparent'
                 }`}
               >
-                <span className={activeSection === section.id ? 'text-accent-primary' : 'text-gray-500'}>
+                <span className={activeSection === section.id ? 'text-accent-secondary' : 'text-dark-300'}>
                   {section.icon}
                 </span>
                 <div>
-                  <p className="font-medium">{section.name}</p>
-                  <p className="text-xs text-gray-600">{section.description}</p>
+                  <p className="font-medium font-ui">{section.name}</p>
+                  <p className="text-xs text-dark-300">{section.description}</p>
                 </div>
               </button>
             ))}
@@ -1081,7 +1081,7 @@ export function SettingsPanel() {
             </button>
             <button
               onClick={resetSettings}
-              className="w-full glass-button flex items-center justify-center gap-2 py-2 text-gray-400"
+              className="w-full glass-button flex items-center justify-center gap-2 py-2 text-dark-300"
             >
               <RotateCcw className="w-4 h-4" />
               <span>Reset to Defaults</span>
@@ -1093,7 +1093,7 @@ export function SettingsPanel() {
         <div className="flex-1 flex flex-col">
           {/* Header with close button */}
           <div className="flex items-center justify-between p-4 border-b border-glass-100">
-            <h3 className="text-lg font-semibold text-gray-100">
+            <h3 className="text-lg font-semibold font-display text-dark-200">
               {SETTINGS_SECTIONS.find((s) => s.id === activeSection)?.name}
             </h3>
             <button onClick={closeSettings} className="p-2 hover:bg-dark-700 rounded-lg transition-colors">
@@ -1106,7 +1106,7 @@ export function SettingsPanel() {
 
           {/* Dirty indicator */}
           {isDirty && (
-            <div className="px-4 py-2 bg-amber-500/10 border-t border-amber-500/30 text-amber-400 text-sm flex items-center gap-2">
+            <div className="px-4 py-2 bg-accent-primary/10 border-t border-accent-primary/30 text-accent-primary text-sm flex items-center gap-2">
               <AlertCircle className="w-4 h-4" />
               <span>You have unsaved changes</span>
             </div>

--- a/src/Log4YM.Web/src/components/StatusBar.tsx
+++ b/src/Log4YM.Web/src/components/StatusBar.tsx
@@ -20,7 +20,7 @@ export function StatusBar() {
   };
 
   return (
-    <div className="h-8 bg-dark-800/90 backdrop-blur-sm border-t border-glass-100 flex items-center justify-between px-4 text-sm">
+    <div className="h-8 bg-dark-800/90 backdrop-blur-sm border-t border-glass-100 flex items-center justify-between px-4 text-sm font-ui">
       {/* Left side - Station info */}
       <div className="flex items-center gap-6">
         <div className="flex items-center gap-2">
@@ -28,21 +28,21 @@ export function StatusBar() {
           <span className="font-mono font-bold text-accent-primary">{stationCallsign}</span>
         </div>
 
-        <div className="flex items-center gap-2 text-gray-400">
+        <div className="flex items-center gap-2 text-dark-300">
           <MapPin className="w-3 h-3" />
           <span className="font-mono">{stationGrid}</span>
         </div>
 
         {rigStatus && (
           <div className="flex items-center gap-2">
-            <span className="frequency-display text-accent-info">
+            <span className="frequency-display text-accent-secondary">
               {formatFrequency(rigStatus.frequency)} MHz
             </span>
             <span className={`badge ${rigStatus.mode === 'CW' ? 'badge-cw' : rigStatus.mode === 'SSB' ? 'badge-ssb' : 'badge-ft8'}`}>
               {rigStatus.mode}
             </span>
             {rigStatus.isTransmitting && (
-              <span className="px-2 py-0.5 bg-accent-danger/20 text-accent-danger rounded text-xs font-bold animate-pulse">
+              <span className="px-2 py-0.5 bg-accent-danger/20 text-accent-danger rounded text-xs font-bold animate-pulse font-mono">
                 TX
               </span>
             )}
@@ -52,7 +52,7 @@ export function StatusBar() {
 
       {/* Right side - Time and connection */}
       <div className="flex items-center gap-6">
-        <div className="flex items-center gap-2 text-gray-400">
+        <div className="flex items-center gap-2 text-dark-300">
           <Clock className="w-3 h-3" />
           <span className="font-mono">{formatUtcTime(currentTime)} UTC</span>
         </div>
@@ -61,33 +61,33 @@ export function StatusBar() {
           {connectionState === 'connected' && (
             <>
               <Wifi className="w-4 h-4 text-accent-success" />
-              <span className="text-accent-success text-xs">Connected</span>
+              <span className="text-accent-success text-xs font-mono">Connected</span>
             </>
           )}
           {connectionState === 'connecting' && (
             <>
-              <Loader2 className="w-4 h-4 text-accent-info animate-spin" />
-              <span className="text-accent-info text-xs">Connecting...</span>
+              <Loader2 className="w-4 h-4 text-accent-secondary animate-spin" />
+              <span className="text-accent-secondary text-xs font-mono">Connecting...</span>
             </>
           )}
           {connectionState === 'reconnecting' && (
             <>
               <Loader2 className="w-4 h-4 text-accent-warning animate-spin" />
-              <span className="text-accent-warning text-xs">
+              <span className="text-accent-warning text-xs font-mono">
                 Reconnecting{reconnectAttempt > 0 ? ` (${reconnectAttempt})` : '...'}
               </span>
             </>
           )}
           {connectionState === 'rehydrating' && (
             <>
-              <Loader2 className="w-4 h-4 text-accent-info animate-spin" />
-              <span className="text-accent-info text-xs">Loading data...</span>
+              <Loader2 className="w-4 h-4 text-accent-secondary animate-spin" />
+              <span className="text-accent-secondary text-xs font-mono">Loading data...</span>
             </>
           )}
           {connectionState === 'disconnected' && (
             <>
               <WifiOff className="w-4 h-4 text-accent-danger" />
-              <span className="text-accent-danger text-xs">Disconnected</span>
+              <span className="text-accent-danger text-xs font-mono">Disconnected</span>
             </>
           )}
         </div>

--- a/src/Log4YM.Web/src/index.css
+++ b/src/Log4YM.Web/src/index.css
@@ -9,70 +9,73 @@
 
   body {
     @apply bg-dark-900 text-gray-100 antialiased;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
   }
 
-  /* Custom scrollbar */
+  /* Custom scrollbar — dark instrument panel */
   ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
   ::-webkit-scrollbar-track {
-    @apply bg-dark-800;
+    background: #0a0e14;
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply bg-dark-500 rounded-full;
+    background: #243044;
+    border-radius: 9999px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-dark-400;
+    background: #2e3d55;
   }
 }
 
 @layer components {
-  /* Glassmorphic panel */
+  /* Glassmorphic panel — OpenHamClock instrument style */
   .glass-panel {
-    @apply bg-dark-800/80 backdrop-blur-xl border border-glass-100 rounded-xl shadow-glass;
+    @apply bg-dark-800/90 backdrop-blur-xl border border-glass-100 rounded-xl shadow-glass;
   }
 
   .glass-panel-solid {
     @apply bg-dark-800 border border-glass-100 rounded-xl shadow-glass;
   }
 
-  /* Glassmorphic input */
+  /* Glassmorphic input — amber-tinted focus */
   .glass-input {
     @apply bg-dark-700/50 backdrop-blur-sm border border-glass-100 rounded-lg px-4 py-2
            text-gray-100 placeholder-gray-500
-           focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary/50
+           focus:outline-none focus:ring-2 focus:ring-accent-primary/40 focus:border-accent-primary/40
            transition-all duration-200;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
   }
 
-  /* Glassmorphic button */
+  /* Glassmorphic button — instrument panel */
   .glass-button {
-    @apply bg-dark-600/80 backdrop-blur-sm border border-glass-100 rounded-lg px-4 py-2
+    @apply bg-dark-700/80 backdrop-blur-sm border border-glass-100 rounded-lg px-4 py-2
            text-gray-100 font-medium
-           hover:bg-dark-500/80 hover:border-glass-200
-           focus:outline-none focus:ring-2 focus:ring-accent-primary/50
+           hover:bg-dark-600/80 hover:border-glass-200
+           focus:outline-none focus:ring-2 focus:ring-accent-primary/40
            active:scale-95
            transition-all duration-200;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
   }
 
   .glass-button-primary {
-    @apply bg-accent-primary/80 backdrop-blur-sm border border-accent-primary/30 rounded-lg px-4 py-2
-           text-white font-medium
-           hover:bg-accent-primary hover:shadow-glow
-           focus:outline-none focus:ring-2 focus:ring-accent-primary/50
+    @apply bg-accent-primary/20 backdrop-blur-sm border border-accent-primary/30 rounded-lg px-4 py-2
+           text-accent-primary font-medium
+           hover:bg-accent-primary/30 hover:shadow-glow
+           focus:outline-none focus:ring-2 focus:ring-accent-primary/40
            active:scale-95
            transition-all duration-200;
   }
 
   .glass-button-success {
-    @apply bg-accent-success/80 backdrop-blur-sm border border-accent-success/30 rounded-lg px-4 py-2
-           text-white font-medium
-           hover:bg-accent-success hover:shadow-glow-success
-           focus:outline-none focus:ring-2 focus:ring-accent-success/50
+    @apply bg-accent-success/20 backdrop-blur-sm border border-accent-success/30 rounded-lg px-4 py-2
+           text-accent-success font-medium
+           hover:bg-accent-success/30 hover:shadow-glow-success
+           focus:outline-none focus:ring-2 focus:ring-accent-success/40
            active:scale-95
            transition-all duration-200;
   }
@@ -80,6 +83,7 @@
   /* Mode badges */
   .badge {
     @apply px-2 py-0.5 rounded-full text-xs font-medium;
+    font-family: 'JetBrains Mono', monospace;
   }
 
   .badge-cw {
@@ -100,17 +104,20 @@
 
   /* Band indicator */
   .band-indicator {
-    @apply px-2 py-0.5 rounded text-xs font-mono font-bold bg-dark-600 text-gray-300;
+    @apply px-2 py-0.5 rounded text-xs font-bold bg-dark-700 text-accent-primary;
+    font-family: 'JetBrains Mono', monospace;
   }
 
   /* Frequency display */
   .frequency-display {
-    @apply font-mono text-lg tracking-wider;
+    @apply text-lg tracking-wider;
+    font-family: 'Orbitron', system-ui, sans-serif;
   }
 
   /* Callsign display */
   .callsign {
-    @apply font-mono font-bold tracking-wide text-accent-primary;
+    @apply font-bold tracking-wide text-accent-primary;
+    font-family: 'JetBrains Mono', monospace;
   }
 
   /* Status indicators */
@@ -119,53 +126,76 @@
   }
 
   .status-connected {
-    @apply bg-accent-success shadow-[0_0_8px_rgba(16,185,129,0.5)];
+    @apply bg-accent-success shadow-[0_0_8px_rgba(0,255,136,0.5)];
   }
 
   .status-disconnected {
-    @apply bg-accent-danger shadow-[0_0_8px_rgba(239,68,68,0.5)];
+    @apply bg-accent-danger shadow-[0_0_8px_rgba(255,68,102,0.5)];
   }
 
   .status-warning {
-    @apply bg-accent-warning shadow-[0_0_8px_rgba(245,158,11,0.5)];
+    @apply bg-accent-warning shadow-[0_0_8px_rgba(255,180,50,0.5)];
   }
 }
 
-/* FlexLayout overrides - VS Code Dark Modern */
+/* FlexLayout overrides — OpenHamClock dark instrument panel */
 .flexlayout__layout {
   @apply bg-transparent;
 }
 
 .flexlayout__tab_button {
-  @apply bg-transparent border-transparent text-gray-400 hover:text-gray-200 hover:bg-dark-700;
+  background: transparent;
+  border-color: transparent;
+  color: #5a7090;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.flexlayout__tab_button:hover {
+  color: #a0b0c0;
+  background: rgba(26, 35, 50, 0.6);
 }
 
 .flexlayout__tab_button--selected {
-  @apply bg-dark-900 text-gray-100 border-b-2 border-b-accent-primary;
+  background: #0a0e14;
+  color: #00ddff;
+  border-bottom: 2px solid #00ddff;
 }
 
 .flexlayout__tabset {
-  @apply bg-dark-800 border border-dark-600 rounded-t-lg overflow-hidden;
+  background: #111820;
+  border: 1px solid rgba(255, 180, 50, 0.1);
+  border-radius: 8px 8px 0 0;
+  overflow: hidden;
 }
 
 .flexlayout__tabset_tabbar_outer {
-  @apply bg-dark-800 border-b border-dark-600;
+  background: #111820;
+  border-bottom: 1px solid rgba(255, 180, 50, 0.1);
 }
 
 .flexlayout__tab {
-  @apply bg-dark-900;
+  background: #0a0e14;
 }
 
 .flexlayout__splitter {
-  @apply bg-dark-600 hover:bg-accent-primary;
+  background: rgba(255, 180, 50, 0.08);
+  transition: background 0.2s ease;
+}
+
+.flexlayout__splitter:hover {
+  background: rgba(0, 221, 255, 0.3);
 }
 
 .flexlayout__border {
-  @apply bg-dark-800;
+  background: #111820;
 }
 
 .flexlayout__tabset_header {
-  @apply bg-dark-800;
+  background: #111820;
 }
 
 .flexlayout__tab_button_content {
@@ -177,70 +207,91 @@
 }
 
 .flexlayout__popup_menu {
-  @apply bg-dark-800 border border-dark-600 rounded shadow-glass;
+  background: #111820;
+  border: 1px solid rgba(255, 180, 50, 0.15);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
 }
 
 .flexlayout__popup_menu_item {
-  @apply px-4 py-2 text-gray-300 hover:bg-dark-700 hover:text-gray-100 cursor-pointer;
+  @apply px-4 py-2 cursor-pointer;
+  color: #a0b0c0;
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.flexlayout__popup_menu_item:hover {
+  background: #1a2332;
+  color: #00ddff;
 }
 
 .flexlayout__drag_rect {
-  @apply bg-accent-primary/20 border-2 border-accent-primary border-dashed rounded;
+  background: rgba(0, 221, 255, 0.1);
+  border: 2px dashed #00ddff;
+  border-radius: 8px;
 }
 
 .flexlayout__outline_rect {
-  @apply border-2 border-accent-primary rounded;
+  border: 2px solid #00ddff;
+  border-radius: 8px;
 }
 
 .flexlayout__edge_rect {
-  @apply bg-accent-primary/30;
+  background: rgba(0, 221, 255, 0.2);
 }
 
 .flexlayout__tabset-selected {
-  @apply ring-1 ring-accent-primary/50;
+  box-shadow: inset 0 0 0 1px rgba(0, 221, 255, 0.3);
 }
 
 .flexlayout__tab_floating {
-  @apply bg-dark-800 border border-dark-600 rounded shadow-2xl;
+  background: #111820;
+  border: 1px solid rgba(255, 180, 50, 0.15);
+  border-radius: 8px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.7);
 }
 
-/* AG Grid Dark Theme Overrides - VS Code Dark Modern */
+/* AG Grid Dark Theme Overrides — OpenHamClock instrument panel */
 .ag-theme-alpine-dark {
-  --ag-background-color: #1e1e1e;
-  --ag-header-background-color: #252526;
-  --ag-odd-row-background-color: #252526;
-  --ag-row-hover-color: rgba(255, 255, 255, 0.05);
-  --ag-selected-row-background-color: rgba(0, 120, 212, 0.2);
-  --ag-border-color: #3c3c3c;
-  --ag-header-foreground-color: #cccccc;
-  --ag-foreground-color: #d4d4d4;
-  --ag-row-border-color: #2d2d2d;
-  --ag-font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  --ag-background-color: #0a0e14;
+  --ag-header-background-color: #111820;
+  --ag-odd-row-background-color: #0e1319;
+  --ag-row-hover-color: rgba(0, 221, 255, 0.06);
+  --ag-selected-row-background-color: rgba(255, 180, 50, 0.12);
+  --ag-border-color: rgba(255, 180, 50, 0.1);
+  --ag-header-foreground-color: #00ff88;
+  --ag-foreground-color: #a0b0c0;
+  --ag-row-border-color: rgba(255, 180, 50, 0.05);
+  --ag-font-family: 'JetBrains Mono', 'Consolas', monospace;
   --ag-font-size: 13px;
   --ag-grid-size: 4px;
   --ag-cell-horizontal-padding: 12px;
-  --ag-header-column-separator-color: #3c3c3c;
-  --ag-header-column-resize-handle-color: #0078d4;
-  --ag-range-selection-border-color: #0078d4;
-  --ag-input-focus-border-color: #0078d4;
-  --ag-checkbox-checked-color: #0078d4;
-  --ag-range-selection-background-color: rgba(0, 120, 212, 0.2);
+  --ag-header-column-separator-color: rgba(255, 180, 50, 0.1);
+  --ag-header-column-resize-handle-color: #00ddff;
+  --ag-range-selection-border-color: #00ddff;
+  --ag-input-focus-border-color: #ffb432;
+  --ag-checkbox-checked-color: #ffb432;
+  --ag-range-selection-background-color: rgba(0, 221, 255, 0.1);
 }
 
 .ag-theme-alpine-dark .ag-root-wrapper {
-  background-color: #1e1e1e;
-  border: 1px solid #3c3c3c;
+  background-color: #0a0e14;
+  border: 1px solid rgba(255, 180, 50, 0.1);
   border-radius: 4px;
   overflow: hidden;
 }
 
 .ag-theme-alpine-dark .ag-header {
-  background-color: #252526;
-  border-bottom: 1px solid #3c3c3c;
+  background-color: #111820;
+  border-bottom: 1px solid rgba(255, 180, 50, 0.1);
 }
 
 .ag-theme-alpine-dark .ag-header-cell {
-  @apply font-medium text-sm;
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .ag-theme-alpine-dark .ag-header-cell-resize {
@@ -248,21 +299,21 @@
 }
 
 .ag-theme-alpine-dark .ag-header-cell-resize::after {
-  background-color: #0078d4;
+  background-color: #00ddff;
 }
 
 .ag-theme-alpine-dark .ag-row {
-  background-color: #1e1e1e;
-  border-bottom: 1px solid #2d2d2d;
+  background-color: #0a0e14;
+  border-bottom: 1px solid rgba(255, 180, 50, 0.04);
   transition: background-color 0.1s ease;
 }
 
 .ag-theme-alpine-dark .ag-row-odd {
-  background-color: #252526;
+  background-color: #0e1319;
 }
 
 .ag-theme-alpine-dark .ag-row:hover {
-  background-color: #2a2d2e !important;
+  background-color: rgba(0, 221, 255, 0.06) !important;
 }
 
 .ag-theme-alpine-dark .ag-cell {
@@ -270,18 +321,18 @@
 }
 
 .ag-theme-alpine-dark .ag-body-viewport {
-  background-color: #1e1e1e;
+  background-color: #0a0e14;
 }
 
 .ag-theme-alpine-dark .ag-overlay-no-rows-wrapper {
-  background-color: #1e1e1e;
+  background-color: #0a0e14;
 }
 
 .ag-theme-alpine-dark .ag-overlay-no-rows-center {
-  color: #6e6e6e;
+  color: #5a7090;
 }
 
-/* Header Plugin - dockable status bar */
+/* Header Plugin — dockable instrument bar */
 .header-plugin {
   display: flex;
   align-items: center;
@@ -292,8 +343,8 @@
   height: 100%;
   width: 100%;
   min-height: 0;
-  background: #141418;
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: #0a0e14;
+  font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
   overflow: hidden;
   box-sizing: border-box;
 }
@@ -310,49 +361,52 @@
 .header-plugin__sep {
   width: 1px;
   height: 32px;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 180, 50, 0.15);
   align-self: center;
   flex-shrink: 0;
 }
 
 .header-plugin__callsign {
-  font-family: 'Impact', 'Arial Narrow', 'Helvetica Neue', sans-serif;
-  font-style: italic;
+  font-family: 'Orbitron', system-ui, sans-serif;
   font-weight: 900;
   font-size: 28px;
-  letter-spacing: 1px;
-  color: #e8a020;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+  letter-spacing: 2px;
+  color: #ffb432;
+  text-shadow: 0 0 12px rgba(255, 180, 50, 0.3);
   line-height: 1;
 }
 
 .header-plugin__version {
+  font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
-  color: #707070;
+  color: #5a7090;
   align-self: flex-end;
   margin-bottom: 2px;
 }
 
 .header-plugin__label {
+  font-family: 'Space Grotesk', system-ui, sans-serif;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 1.5px;
   text-transform: uppercase;
-  color: #2a9d8f;
+  color: #00ff88;
 }
 
 .header-plugin__time {
-  font-family: 'Consolas', 'SF Mono', 'Fira Code', monospace;
+  font-family: 'Orbitron', system-ui, sans-serif;
   font-size: 28px;
   font-weight: 700;
-  color: #e8a020;
+  color: #ffb432;
   letter-spacing: 2px;
   line-height: 1;
+  text-shadow: 0 0 10px rgba(255, 180, 50, 0.2);
 }
 
 .header-plugin__date {
+  font-family: 'JetBrains Mono', monospace;
   font-size: 13px;
-  color: #707070;
+  color: #5a7090;
   align-self: flex-end;
   margin-bottom: 2px;
 }
@@ -363,10 +417,10 @@
 }
 
 .header-plugin__weather-temp {
-  font-family: 'Consolas', 'SF Mono', 'Fira Code', monospace;
+  font-family: 'JetBrains Mono', monospace;
   font-size: 16px;
   font-weight: 600;
-  color: #2a9d8f;
+  color: #00ddff;
 }
 
 .header-plugin__indices {
@@ -374,14 +428,15 @@
 }
 
 .header-plugin__value {
-  font-family: 'Consolas', 'SF Mono', 'Fira Code', monospace;
+  font-family: 'Orbitron', system-ui, sans-serif;
   font-size: 16px;
   font-weight: 700;
-  color: #e8a020;
+  color: #ffb432;
 }
 
 .header-plugin__value--danger {
-  color: #f14c4c;
+  color: #ff4466;
+  text-shadow: 0 0 8px rgba(255, 68, 102, 0.4);
 }
 
 /* Custom animations */
@@ -402,4 +457,20 @@
 
 .radio-wave {
   animation: radio-wave 2s ease-out infinite;
+}
+
+/* CRT scanline effect — very subtle atmosphere */
+.crt-scanlines::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.02) 2px,
+    rgba(0, 0, 0, 0.02) 4px
+  );
+  z-index: 9999;
 }

--- a/src/Log4YM.Web/src/plugins/AnalogClockPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/AnalogClockPlugin.tsx
@@ -78,7 +78,7 @@ export function AnalogClockPlugin() {
         y1={CY + outerR * Math.sin(rad)}
         x2={CX + innerR * Math.cos(rad)}
         y2={CY + innerR * Math.sin(rad)}
-        stroke={isMajor ? '#9ca3af' : '#4b5563'}
+        stroke={isMajor ? '#a0b0c0' : '#5a7090'}
         strokeWidth={isMajor ? 1.5 : 0.5}
         strokeLinecap="round"
       />
@@ -98,10 +98,10 @@ export function AnalogClockPlugin() {
         y={CY + numR * Math.sin(rad)}
         textAnchor="middle"
         dominantBaseline="central"
-        fill="#9ca3af"
+        fill="#a0b0c0"
         fontSize={R * 0.14}
         fontWeight="500"
-        fontFamily="system-ui, -apple-system, sans-serif"
+        fontFamily="Orbitron, system-ui, sans-serif"
       >
         {i}
       </text>
@@ -116,8 +116,8 @@ export function AnalogClockPlugin() {
       <div ref={containerRef} className="w-full h-full flex flex-col items-center justify-center p-2 select-none">
         {/* Date info above clock */}
         <div className="flex w-full justify-between px-4 pb-1 shrink-0">
-          <span className="text-xs font-semibold text-gray-300 tracking-wider">{dayOfWeek}</span>
-          <span className="text-xs font-semibold text-gray-300 tracking-wider">{month} {date}</span>
+          <span className="text-xs font-display font-semibold text-dark-300 tracking-wider">{dayOfWeek}</span>
+          <span className="text-xs font-display font-semibold text-dark-300 tracking-wider">{month} {date}</span>
         </div>
 
         {/* Clock face — SVG uses viewBox so it scales to fill available space */}
@@ -133,8 +133,8 @@ export function AnalogClockPlugin() {
               cx={CX}
               cy={CY}
               r={R}
-              fill="transparent"
-              stroke="#374151"
+              fill="#0a0e14"
+              stroke="#5a7090"
               strokeWidth={1.5}
             />
 
@@ -149,11 +149,11 @@ export function AnalogClockPlugin() {
               x={CX}
               y={CY - R * 0.35}
               textAnchor="middle"
-              fill="#6b7280"
+              fill="#5a7090"
               fontSize={R * 0.09}
               fontWeight="400"
               letterSpacing="0.1em"
-              fontFamily="system-ui, -apple-system, sans-serif"
+              fontFamily="Space Grotesk, system-ui, sans-serif"
             >
               LOCAL
             </text>
@@ -164,7 +164,7 @@ export function AnalogClockPlugin() {
               y1={CY}
               x2={hourHand.x}
               y2={hourHand.y}
-              stroke="#d1d5db"
+              stroke="#ffb432"
               strokeWidth={3}
               strokeLinecap="round"
             />
@@ -175,7 +175,7 @@ export function AnalogClockPlugin() {
               y1={CY}
               x2={minuteHand.x}
               y2={minuteHand.y}
-              stroke="#d1d5db"
+              stroke="#ffb432"
               strokeWidth={2}
               strokeLinecap="round"
             />
@@ -186,7 +186,7 @@ export function AnalogClockPlugin() {
               y1={CY}
               x2={secondHand.x}
               y2={secondHand.y}
-              stroke="#ef4444"
+              stroke="#ff4466"
               strokeWidth={0.8}
               strokeLinecap="round"
             />
@@ -196,27 +196,27 @@ export function AnalogClockPlugin() {
               cx={CX}
               cy={CY}
               r={3}
-              fill="#d1d5db"
+              fill="#ffb432"
             />
             <circle
               cx={CX}
               cy={CY}
               r={1.5}
-              fill="#ef4444"
+              fill="#ff4466"
             />
           </svg>
         </div>
 
         {/* Sunrise/Sunset info below clock */}
         <div className="flex w-full justify-between px-4 pt-1 shrink-0">
-          <div className="flex items-center gap-1.5 text-xs text-gray-300">
-            <Sun className="w-3.5 h-3.5 text-yellow-500" />
+          <div className="flex items-center gap-1.5 text-xs text-dark-200">
+            <Sun className="w-3.5 h-3.5 text-accent-primary" />
             <span className="font-mono">
               {sunTimes ? formatTime(sunTimes.sunrise) : '--:--'}
             </span>
           </div>
-          <div className="flex items-center gap-1.5 text-xs text-gray-300">
-            <Moon className="w-3.5 h-3.5 text-blue-300" />
+          <div className="flex items-center gap-1.5 text-xs text-dark-200">
+            <Moon className="w-3.5 h-3.5 text-accent-secondary" />
             <span className="font-mono">
               {sunTimes ? formatTime(sunTimes.sunset) : '--:--'}
             </span>

--- a/src/Log4YM.Web/src/plugins/AntennaGeniusPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/AntennaGeniusPlugin.tsx
@@ -17,10 +17,10 @@ export function AntennaGeniusPlugin() {
         title="Antenna Genius"
         icon={<Radio className="w-5 h-5" />}
       >
-        <div className="flex flex-col items-center justify-center h-full p-8 text-gray-500">
+        <div className="flex flex-col items-center justify-center h-full p-8 text-dark-300">
           <WifiOff className="w-12 h-12 mb-4 opacity-50" />
-          <p className="text-center">No Antenna Genius devices found</p>
-          <p className="text-sm text-gray-600 mt-2 text-center">
+          <p className="text-center font-ui">No Antenna Genius devices found</p>
+          <p className="text-sm text-dark-300 mt-2 text-center font-ui">
             Waiting for device discovery on UDP port 9007...
           </p>
         </div>
@@ -43,7 +43,7 @@ export function AntennaGeniusPlugin() {
               Connected
             </span>
           ) : (
-            <span className="flex items-center gap-1.5 text-xs text-gray-500">
+            <span className="flex items-center gap-1.5 text-xs text-dark-300">
               <WifiOff className="w-3.5 h-3.5" />
               Disconnected
             </span>
@@ -53,8 +53,8 @@ export function AntennaGeniusPlugin() {
     >
       <div className="p-4 space-y-4">
         {/* Device Info */}
-        <div className="text-sm text-gray-400">
-          <span className="font-medium text-gray-200">{device.deviceName}</span>
+        <div className="text-sm text-dark-300 font-mono">
+          <span className="font-medium text-dark-200">{device.deviceName}</span>
           <span className="mx-2">|</span>
           <span>v{device.version}</span>
           <span className="mx-2">|</span>
@@ -105,17 +105,17 @@ function PortHeader({ portId, label, band, isTransmitting }: PortHeaderProps) {
   return (
     <div className="bg-dark-700/50 rounded-lg p-3 border border-glass-100">
       <div className="flex items-center justify-between">
-        <span className={`text-sm font-medium ${portId === 1 ? 'text-accent-primary' : 'text-accent-success'}`}>
+        <span className={`text-sm font-medium font-ui ${portId === 1 ? 'text-accent-primary' : 'text-accent-success'}`}>
           {label}
         </span>
         {isTransmitting && (
-          <span className="flex items-center gap-1 text-xs text-red-500 animate-pulse">
+          <span className="flex items-center gap-1 text-xs text-accent-danger animate-pulse">
             <Zap className="w-3 h-3" />
             TX
           </span>
         )}
       </div>
-      <div className="mt-1 text-lg font-bold text-gray-100">
+      <div className="mt-1 text-lg font-bold text-dark-200 font-mono">
         {band?.name || 'None'}
       </div>
     </div>
@@ -141,7 +141,7 @@ function AntennaRow({ antenna, device, onSelectA, onSelectB }: AntennaRowProps) 
         flex items-center gap-2 p-2 rounded-lg border transition-all duration-200
         ${isSelectedA || isSelectedB
           ? 'bg-dark-600/70 border-glass-200'
-          : 'bg-dark-700/30 border-glass-100 hover:bg-dark-700/50'
+          : 'bg-dark-700/30 border-glass-100 hover:bg-dark-600'
         }
       `}
     >
@@ -152,9 +152,9 @@ function AntennaRow({ antenna, device, onSelectA, onSelectB }: AntennaRowProps) 
           w-8 h-8 rounded flex items-center justify-center text-xs font-bold transition-all
           ${isSelectedA
             ? isTxA
-              ? 'bg-red-500/80 text-white ring-2 ring-red-400 animate-pulse'
+              ? 'bg-accent-danger/80 text-white ring-2 ring-accent-danger animate-pulse'
               : 'bg-accent-primary text-white'
-            : 'bg-dark-600 text-gray-500 hover:bg-accent-primary/30 hover:text-accent-primary'
+            : 'bg-dark-600 text-dark-300 hover:bg-accent-primary/30 hover:text-accent-primary'
           }
         `}
         title={`Select for Radio A`}
@@ -166,8 +166,8 @@ function AntennaRow({ antenna, device, onSelectA, onSelectB }: AntennaRowProps) 
       <div className="flex-1 min-w-0">
         <span
           className={`
-            text-sm font-medium truncate block
-            ${isSelectedA || isSelectedB ? 'text-gray-100' : 'text-gray-400'}
+            text-sm font-medium font-mono truncate block
+            ${isSelectedA || isSelectedB ? 'text-dark-200' : 'text-dark-300'}
           `}
         >
           {antenna.name}
@@ -181,9 +181,9 @@ function AntennaRow({ antenna, device, onSelectA, onSelectB }: AntennaRowProps) 
           w-8 h-8 rounded flex items-center justify-center text-xs font-bold transition-all
           ${isSelectedB
             ? isTxB
-              ? 'bg-red-500/80 text-white ring-2 ring-red-400 animate-pulse'
+              ? 'bg-accent-danger/80 text-white ring-2 ring-accent-danger animate-pulse'
               : 'bg-accent-success text-white'
-            : 'bg-dark-600 text-gray-500 hover:bg-accent-success/30 hover:text-accent-success'
+            : 'bg-dark-600 text-dark-300 hover:bg-accent-success/30 hover:text-accent-success'
           }
         `}
         title={`Select for Radio B`}

--- a/src/Log4YM.Web/src/plugins/ClusterPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/ClusterPlugin.tsx
@@ -143,7 +143,7 @@ const ModeCellRenderer = (props: ICellRendererParams<Spot>) => {
     mode = inferModeFromFrequency(freq);
   }
 
-  if (!mode) return <span className="text-gray-500">?</span>;
+  if (!mode) return <span className="text-dark-300">?</span>;
 
   // Normalize mode display
   const displayMode = (m: string) => {
@@ -162,7 +162,7 @@ const ModeCellRenderer = (props: ICellRendererParams<Spot>) => {
       case 'FT4': return 'badge-ft8';
       case 'RTTY':
       case 'PSK31': return 'badge-rtty';
-      default: return 'bg-dark-600 text-gray-300';
+      default: return 'bg-dark-600 text-dark-200';
     }
   };
   return <span className={`badge text-xs ${getModeClass(mode)}`}>{displayMode(mode)}</span>;
@@ -170,7 +170,7 @@ const ModeCellRenderer = (props: ICellRendererParams<Spot>) => {
 
 // Custom cell renderer for frequency
 const FrequencyCellRenderer = (props: ICellRendererParams<Spot>) => {
-  return <span className="frequency-display text-accent-info text-sm">{formatFrequency(props.value)}</span>;
+  return <span className="frequency-display font-mono text-accent-info text-sm">{formatFrequency(props.value)}</span>;
 };
 
 // Custom cell renderer for country flag
@@ -185,9 +185,9 @@ const TimeCellRenderer = (props: ICellRendererParams<Spot>) => {
   const time = props.data?.timestamp || props.value;
   const age = getAge(time);
   return (
-    <div className="flex items-center gap-2 text-gray-400">
+    <div className="flex items-center gap-2 text-dark-300">
       <span className="font-mono">{formatTime(time)}</span>
-      <span className="text-xs text-gray-600">({age})</span>
+      <span className="text-xs text-dark-400">({age})</span>
     </div>
   );
 };
@@ -219,10 +219,10 @@ function ClusterSettingsPanel({
 
   const getStatusColor = (status?: ClusterStatusType) => {
     switch (status) {
-      case 'connected': return 'bg-green-500';
-      case 'connecting': return 'bg-yellow-500 animate-pulse';
-      case 'error': return 'bg-red-500';
-      default: return 'bg-gray-500';
+      case 'connected': return 'bg-accent-success';
+      case 'connecting': return 'bg-accent-primary animate-pulse';
+      case 'error': return 'bg-accent-danger';
+      default: return 'bg-dark-400';
     }
   };
 
@@ -251,16 +251,16 @@ function ClusterSettingsPanel({
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <div className={`w-2.5 h-2.5 rounded-full ${getStatusColor(status)}`} />
-                <span className="text-sm font-medium text-gray-300">
+                <span className="text-sm font-medium font-ui text-dark-200">
                   {conn.name || `Cluster ${index + 1}`}
                 </span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-dark-300">
                   ({getStatusText(status)})
                 </span>
               </div>
               <button
                 onClick={() => onRemoveConnection(conn.id)}
-                className="p-1 text-gray-500 hover:text-red-400 transition-colors"
+                className="p-1 text-dark-300 hover:text-accent-danger transition-colors"
                 title="Remove cluster"
               >
                 <Trash2 className="w-4 h-4" />
@@ -271,50 +271,50 @@ function ClusterSettingsPanel({
             <div className="grid grid-cols-2 gap-3">
               {/* Name */}
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Name</label>
+                <label className="block text-xs font-ui text-dark-300 mb-1">Name</label>
                 <input
                   type="text"
                   value={conn.name}
                   onChange={(e) => onUpdateConnection(conn.id, { name: e.target.value })}
                   placeholder="Cluster name"
-                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-accent-primary/50"
+                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm text-dark-200 placeholder-dark-400 focus:outline-none focus:border-accent-primary/50"
                 />
               </div>
 
               {/* Host */}
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Host</label>
+                <label className="block text-xs font-ui text-dark-300 mb-1">Host</label>
                 <input
                   type="text"
                   value={conn.host}
                   onChange={(e) => onUpdateConnection(conn.id, { host: e.target.value })}
                   placeholder="e.g., de.ve7cc.net"
-                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-accent-primary/50"
+                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm text-dark-200 placeholder-dark-400 focus:outline-none focus:border-accent-primary/50"
                 />
               </div>
 
               {/* Port */}
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Port</label>
+                <label className="block text-xs font-ui text-dark-300 mb-1">Port</label>
                 <input
                   type="number"
                   value={conn.port}
                   onChange={(e) => onUpdateConnection(conn.id, { port: parseInt(e.target.value) || 23 })}
-                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm text-gray-200 focus:outline-none focus:border-accent-primary/50"
+                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm font-mono text-dark-200 focus:outline-none focus:border-accent-primary/50"
                 />
               </div>
 
               {/* Callsign */}
               <div>
-                <label className="block text-xs text-gray-500 mb-1">
-                  Callsign <span className="text-gray-600">(blank = station)</span>
+                <label className="block text-xs font-ui text-dark-300 mb-1">
+                  Callsign <span className="text-dark-400">(blank = station)</span>
                 </label>
                 <input
                   type="text"
                   value={conn.callsign || ''}
                   onChange={(e) => onUpdateConnection(conn.id, { callsign: e.target.value || null })}
                   placeholder={stationCallsign || 'Your callsign'}
-                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-accent-primary/50"
+                  className="w-full px-2 py-1.5 bg-dark-900 border border-glass-100 rounded text-sm font-mono text-dark-200 placeholder-dark-400 focus:outline-none focus:border-accent-primary/50"
                 />
               </div>
             </div>
@@ -328,9 +328,9 @@ function ClusterSettingsPanel({
                     type="checkbox"
                     checked={conn.enabled}
                     onChange={(e) => onUpdateConnection(conn.id, { enabled: e.target.checked })}
-                    className="w-4 h-4 rounded border-glass-200 bg-dark-900 text-accent-primary focus:ring-accent-primary/50"
+                    className="w-4 h-4 rounded border-glass-200 bg-dark-900 text-accent-primary focus:ring-accent-primary/40"
                   />
-                  <span className="text-sm text-gray-400">Enabled</span>
+                  <span className="text-sm font-ui text-dark-300">Enabled</span>
                 </label>
 
                 {/* Auto-Reconnect Toggle */}
@@ -339,9 +339,9 @@ function ClusterSettingsPanel({
                     type="checkbox"
                     checked={conn.autoReconnect}
                     onChange={(e) => onUpdateConnection(conn.id, { autoReconnect: e.target.checked })}
-                    className="w-4 h-4 rounded border-glass-200 bg-dark-900 text-accent-primary focus:ring-accent-primary/50"
+                    className="w-4 h-4 rounded border-glass-200 bg-dark-900 text-accent-primary focus:ring-accent-primary/40"
                   />
-                  <span className="text-sm text-gray-400">Auto-reconnect</span>
+                  <span className="text-sm font-ui text-dark-300">Auto-reconnect</span>
                 </label>
               </div>
 
@@ -350,9 +350,9 @@ function ClusterSettingsPanel({
                 onClick={() => isConnected ? onDisconnect(conn.id) : onConnect(conn.id)}
                 disabled={isConnecting || !conn.host}
                 className={`
-                  px-3 py-1.5 rounded text-sm font-medium transition-colors
+                  px-3 py-1.5 rounded text-sm font-medium font-ui transition-colors
                   ${isConnected
-                    ? 'bg-red-500/20 text-red-400 hover:bg-red-500/30'
+                    ? 'bg-accent-danger/20 text-accent-danger hover:bg-accent-danger/30'
                     : 'bg-accent-primary/20 text-accent-primary hover:bg-accent-primary/30'
                   }
                   disabled:opacity-50 disabled:cursor-not-allowed
@@ -369,7 +369,7 @@ function ClusterSettingsPanel({
       {canAddMore && (
         <button
           onClick={onAddConnection}
-          className="w-full flex items-center justify-center gap-2 px-4 py-3 border-2 border-dashed border-glass-100 rounded-lg text-gray-400 hover:border-accent-primary/50 hover:text-accent-primary transition-colors"
+          className="w-full flex items-center justify-center gap-2 px-4 py-3 border-2 border-dashed border-glass-100 rounded-lg text-dark-300 hover:border-accent-primary/50 hover:text-accent-primary transition-colors font-ui"
         >
           <Plus className="w-4 h-4" />
           Add Cluster (max 4)
@@ -377,11 +377,11 @@ function ClusterSettingsPanel({
       )}
 
       {connections.length === 0 && (
-        <div className="text-center py-6 text-gray-500">
-          <p className="mb-2">No cluster connections configured</p>
+        <div className="text-center py-6 text-dark-300">
+          <p className="mb-2 font-ui">No cluster connections configured</p>
           <button
             onClick={onAddConnection}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-colors font-ui"
           >
             <Plus className="w-4 h-4" />
             Add your first cluster
@@ -548,7 +548,7 @@ export function ClusterPlugin() {
       headerName: 'Band',
       field: 'frequency',
       valueGetter: (params) => getBandFromFrequency(params.data?.frequency || 0),
-      cellClass: 'font-mono text-gray-400',
+      cellClass: 'font-mono text-dark-300',
       width: 60,
       resizable: true,
     },
@@ -570,21 +570,21 @@ export function ClusterPlugin() {
     {
       headerName: 'Country',
       valueGetter: (params) => params.data?.dxStation?.country || params.data?.country || '-',
-      cellClass: 'text-gray-400',
+      cellClass: 'text-dark-300',
       width: 100,
       resizable: true,
     },
     {
       headerName: 'Spotter',
       field: 'spotter',
-      cellClass: 'font-mono text-gray-500',
+      cellClass: 'font-mono text-dark-300',
       width: 100,
       resizable: true,
     },
     {
       headerName: 'Comment',
       field: 'comment',
-      cellClass: 'text-gray-500 truncate',
+      cellClass: 'text-dark-300 truncate',
       flex: 1,
       minWidth: 100,
       resizable: true,
@@ -604,23 +604,23 @@ export function ClusterPlugin() {
         <div className="flex items-center gap-2">
           {/* Connected clusters indicator */}
           {clusterConnections.length > 0 && (
-            <span className="text-xs text-gray-500">
+            <span className="text-xs font-ui text-dark-300">
               {connectedCount}/{clusterConnections.length} connected
             </span>
           )}
-          <span className="text-sm text-gray-400">
+          <span className="text-sm font-mono text-dark-300">
             {filteredSpots?.length || 0} spots
           </span>
           <button
             onClick={() => setSoundEnabled(!soundEnabled)}
-            className={`glass-button p-1.5 ${soundEnabled ? 'text-accent-success' : 'text-gray-500'}`}
+            className={`glass-button p-1.5 ${soundEnabled ? 'text-accent-success' : 'text-dark-300'}`}
             title={soundEnabled ? 'Disable alerts' : 'Enable alerts'}
           >
             {soundEnabled ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
           </button>
           <button
             onClick={() => setShowSettings(!showSettings)}
-            className={`glass-button p-1.5 ${showSettings ? 'text-accent-primary' : 'text-gray-500'}`}
+            className={`glass-button p-1.5 ${showSettings ? 'text-accent-primary' : 'text-dark-300'}`}
             title="Cluster settings"
           >
             <Settings className="w-4 h-4" />
@@ -638,10 +638,10 @@ export function ClusterPlugin() {
         >
           <div className="p-4 border-b border-glass-100 bg-dark-900/30">
             <div className="flex items-center justify-between mb-3">
-              <h4 className="text-sm font-medium text-gray-300">Cluster Connections</h4>
+              <h4 className="text-sm font-medium font-ui text-dark-200">Cluster Connections</h4>
               <button
                 onClick={() => setShowSettings(false)}
-                className="p-1 text-gray-500 hover:text-gray-300"
+                className="p-1 text-dark-300 hover:text-dark-200"
               >
                 <ChevronUp className="w-4 h-4" />
               </button>
@@ -661,7 +661,7 @@ export function ClusterPlugin() {
               <div className="mt-4 flex justify-end">
                 <button
                   onClick={() => saveSettings()}
-                  className="px-4 py-2 bg-accent-primary text-white rounded-lg text-sm font-medium hover:bg-accent-primary/80 transition-colors"
+                  className="px-4 py-2 bg-accent-primary text-white rounded-lg text-sm font-medium font-ui hover:bg-accent-primary/80 transition-colors"
                 >
                   Save Settings
                 </button>
@@ -675,18 +675,18 @@ export function ClusterPlugin() {
           <div className="flex gap-3 items-center">
             {/* Fuzzy Search Input */}
             <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-dark-300" />
               <input
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search call, country, spotter..."
-                className="w-full pl-9 pr-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-accent-primary/50"
+                className="w-full pl-9 pr-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 placeholder-dark-400 focus:outline-none focus:border-accent-primary/50"
               />
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-300"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-dark-300 hover:text-dark-200"
                 >
                   <X className="w-3.5 h-3.5" />
                 </button>
@@ -713,7 +713,7 @@ export function ClusterPlugin() {
             {hasActiveFilters && (
               <button
                 onClick={clearAllFilters}
-                className="flex items-center gap-1.5 px-3 py-2 bg-accent-warning/20 text-accent-warning rounded-lg text-sm hover:bg-accent-warning/30 transition-colors whitespace-nowrap"
+                className="flex items-center gap-1.5 px-3 py-2 bg-accent-warning/20 text-accent-warning rounded-lg text-sm font-ui hover:bg-accent-warning/30 transition-colors whitespace-nowrap"
                 title="Clear all filters"
               >
                 <X className="w-4 h-4" />
@@ -727,18 +727,18 @@ export function ClusterPlugin() {
         <div className="flex-1 px-4 pb-4 min-h-0">
           <div className="ag-theme-alpine-dark h-full">
             {isLoading ? (
-              <div className="flex items-center justify-center py-8 text-gray-500">
+              <div className="flex items-center justify-center py-8 text-dark-300">
                 <Radio className="w-4 h-4 animate-spin mr-2" />
                 Loading spots...
               </div>
             ) : filteredSpots?.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-dark-300">
                 {hasActiveFilters ? (
                   <>
                     <p>No spots match your filters</p>
                     <button
                       onClick={clearAllFilters}
-                      className="mt-2 text-accent-primary hover:underline"
+                      className="mt-2 text-accent-primary hover:underline font-ui"
                     >
                       Clear filters
                     </button>

--- a/src/Log4YM.Web/src/plugins/GlobePlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/GlobePlugin.tsx
@@ -79,12 +79,12 @@ export function GlobePlugin() {
   // Get station coordinates from settings - prioritize lat/lon, fall back to grid square, then defaults
   let stationLat = DEFAULT_LAT;
   let stationLon = DEFAULT_LON;
-  
+
   // First priority: explicit lat/lon in settings
   if (settings.station.latitude != null && settings.station.longitude != null) {
     stationLat = settings.station.latitude;
     stationLon = settings.station.longitude;
-  } 
+  }
   // Second priority: convert grid square to coordinates
   else if (settings.station.gridSquare) {
     const coords = gridToLatLon(settings.station.gridSquare);
@@ -150,7 +150,7 @@ export function GlobePlugin() {
 
   // Track target bearing separately from rotator azimuth
   const targetBearingRef = useRef<number | null>(null);
-  
+
   // Track focused callsign info for label callback
   const focusedCallsignInfoRef = useRef<CallsignLookedUpEvent | null>(null);
   focusedCallsignInfoRef.current = focusedCallsignInfo;
@@ -169,7 +169,7 @@ export function GlobePlugin() {
 
     // Render rotator beam only when connected
     if (isConnected) {
-      // Create left and right edge paths (yellow/amber)
+      // Create left and right edge paths (amber accent)
       for (const edge of ['left', 'right']) {
         const pathPoints: [number, number, number][] = [];
 
@@ -187,12 +187,12 @@ export function GlobePlugin() {
 
         pathsData.push({
           path: pathPoints,
-          color: `rgba(251, 191, 36, ${pulseFactor})`, // Yellow/amber for edges
+          color: `rgba(255, 180, 50, ${pulseFactor})`, // Amber accent for edges
           stroke: 3
         });
       }
 
-      // Rotator center line (yellow/amber)
+      // Rotator center line (amber accent)
       const centerPath: [number, number, number][] = [];
       for (let i = 0; i <= numSegments; i++) {
         const distance = (maxDistance / numSegments) * i;
@@ -202,12 +202,12 @@ export function GlobePlugin() {
 
       pathsData.push({
         path: centerPath,
-        color: 'rgba(251, 191, 36, 0.7)', // Yellow/amber center line
+        color: 'rgba(255, 180, 50, 0.7)', // Amber accent center line
         stroke: 2.5
       });
     }
 
-    // Render target heading line (orange) - always show when we have a target
+    // Render target heading line (red/danger) - always show when we have a target
     if (targetBearing !== null) {
       const targetPath: [number, number, number][] = [];
       for (let i = 0; i <= numSegments; i++) {
@@ -218,7 +218,7 @@ export function GlobePlugin() {
 
       pathsData.push({
         path: targetPath,
-        color: 'rgba(249, 115, 22, 0.8)', // Orange (#f97316) for target
+        color: 'rgba(255, 68, 102, 0.8)', // Danger red (#ff4466) for target
         stroke: 2
       });
     }
@@ -394,7 +394,7 @@ export function GlobePlugin() {
         .bumpImageUrl('//unpkg.com/three-globe/example/img/earth-topology.png')
         .backgroundImageUrl('//unpkg.com/three-globe/example/img/night-sky.png')
         .showAtmosphere(true)
-        .atmosphereColor('rgba(99, 102, 241, 0.4)')
+        .atmosphereColor('rgba(10, 14, 20, 0.4)')
         .atmosphereAltitude(0.25)
         .pointOfView({ lat: stationLat, lng: stationLon, altitude: 2.5 })
         .enablePointerInteraction(true);
@@ -414,17 +414,17 @@ export function GlobePlugin() {
         .pointLabel((d: unknown) => {
           const data = d as GlobeMarkerData;
           if (data.type === 'station') {
-            return `<div style="text-align: center; padding: 5px; background: rgba(0, 0, 0, 0.8); border-radius: 3px; color: white;">
-              <div style="font-weight: bold;">${data.label}</div>
+            return `<div style="text-align: center; padding: 5px; background: rgba(10, 14, 20, 0.9); border-radius: 3px; color: #8899aa; border: 1px solid rgba(255, 180, 50, 0.12);">
+              <div style="font-weight: bold; color: #ffb432;">${data.label}</div>
               <div style="font-size: 0.8em;">Station Location</div>
             </div>`;
           } else {
             // Target marker - use ref to access latest focusedCallsignInfo
             const info = focusedCallsignInfoRef.current;
-            return `<div style="text-align: center; padding: 5px; background: rgba(0, 0, 0, 0.8); border-radius: 3px; color: white;">
-              <div style="font-weight: bold; color: #f97316;">${data.label}</div>
-              ${info?.grid ? `<div style="font-size: 0.8em;">${info.grid}</div>` : ''}
-              ${info?.bearing != null ? `<div style="font-size: 0.8em; color: #60a5fa;">
+            return `<div style="text-align: center; padding: 5px; background: rgba(10, 14, 20, 0.9); border-radius: 3px; color: #8899aa; border: 1px solid rgba(255, 180, 50, 0.12);">
+              <div style="font-weight: bold; color: #ff4466;">${data.label}</div>
+              ${info?.grid ? `<div style="font-size: 0.8em; color: #8899aa;">${info.grid}</div>` : ''}
+              ${info?.bearing != null ? `<div style="font-size: 0.8em; color: #00ddff;">
                 ${info.bearing.toFixed(0)}° / ${Math.round(info.distance ?? 0)} km
               </div>` : ''}
             </div>`;
@@ -589,7 +589,7 @@ export function GlobePlugin() {
       lat: stationLat,
       lng: stationLon,
       label: stationGrid || 'Station',
-      color: '#fbbf24', // Yellow to match beam color
+      color: '#ffb432', // Amber accent to match beam color
       size: 0.05,
       type: 'station',
     }];
@@ -600,7 +600,7 @@ export function GlobePlugin() {
         lat: focusedCallsignInfo.latitude,
         lng: focusedCallsignInfo.longitude,
         label: focusedCallsignInfo.callsign,
-        color: '#f97316', // Orange for target (matches map plugin)
+        color: '#ff4466', // Danger red for target
         size: 0.04,
         type: 'target',
       });
@@ -730,7 +730,7 @@ export function GlobePlugin() {
           {rotatorEnabled ? (
             <span className="text-sm font-mono text-accent-primary">{currentAzimuth}°</span>
           ) : (
-            <span className="text-sm text-gray-500">No Rotator</span>
+            <span className="text-sm font-ui text-dark-300">No Rotator</span>
           )}
           <button
             onClick={toggleFullscreen}
@@ -747,10 +747,10 @@ export function GlobePlugin() {
         {webglError && (
           <div className="absolute inset-0 flex items-center justify-center bg-dark-800/95 backdrop-blur-sm z-50">
             <div className="glass-panel p-6 max-w-md text-center">
-              <GlobeIcon className="w-12 h-12 mx-auto mb-4 text-gray-500" />
-              <h3 className="text-lg font-semibold mb-2 text-gray-300">WebGL Not Available</h3>
-              <p className="text-sm text-gray-400 mb-4">{webglError}</p>
-              <p className="text-xs text-gray-500">
+              <GlobeIcon className="w-12 h-12 mx-auto mb-4 text-dark-300" />
+              <h3 className="text-lg font-semibold mb-2 font-ui text-dark-200">WebGL Not Available</h3>
+              <p className="text-sm text-dark-300 mb-4">{webglError}</p>
+              <p className="text-xs text-dark-300">
                 Try using a modern browser like Chrome, Firefox, or Edge.
                 The 2D Map plugin provides similar functionality without WebGL.
               </p>
@@ -768,32 +768,32 @@ export function GlobePlugin() {
         {/* Compass overlay - only show when rotator enabled */}
         {rotatorEnabled && (
           <div className="absolute top-4 right-4 w-32 h-32 bg-dark-800/90 backdrop-blur-sm rounded-full border-2 border-glass-200 flex items-center justify-center">
-            <span className="absolute top-1 text-xs font-bold text-accent-danger">N</span>
-            <span className="absolute bottom-1 text-xs font-bold text-gray-500">S</span>
-            <span className="absolute left-1 text-xs font-bold text-gray-500">W</span>
-            <span className="absolute right-1 text-xs font-bold text-gray-500">E</span>
+            <span className="absolute top-1 text-xs font-bold font-ui text-accent-danger">N</span>
+            <span className="absolute bottom-1 text-xs font-bold font-ui text-dark-300">S</span>
+            <span className="absolute left-1 text-xs font-bold font-ui text-dark-300">W</span>
+            <span className="absolute right-1 text-xs font-bold font-ui text-dark-300">E</span>
 
             {/* Compass needle */}
             <div
               className="absolute w-1 h-12 origin-bottom transition-transform duration-300"
               style={{
                 transform: `rotate(${currentAzimuth}deg)`,
-                background: 'linear-gradient(to top, transparent, #fbbf24)',
+                background: 'linear-gradient(to top, transparent, #ffb432)',
                 top: 'calc(50% - 48px)',
               }}
             />
 
             {/* Center display */}
             <div className="text-center z-10">
-              <div className="text-xl font-bold text-accent-primary">{currentAzimuth}°</div>
-              <div className="text-xs text-gray-500">Azimuth</div>
+              <div className="text-xl font-bold font-mono text-accent-primary">{currentAzimuth}°</div>
+              <div className="text-xs font-ui text-dark-300">Azimuth</div>
             </div>
           </div>
         )}
 
         {/* Info overlay */}
         <div className="absolute bottom-4 left-4 glass-panel px-3 py-2 text-xs">
-          <div className="flex items-center gap-2 text-gray-400">
+          <div className="flex items-center gap-2 font-ui text-dark-300">
             <Navigation className="w-3 h-3" />
             <span>{rotatorEnabled ? 'Click on globe to set bearing' : 'Rotator disabled'}</span>
           </div>
@@ -809,10 +809,10 @@ export function GlobePlugin() {
                   {focusedCallsignInfo.callsign}
                 </p>
                 {focusedCallsignInfo.grid && (
-                  <p className="text-xs text-gray-400">{focusedCallsignInfo.grid}</p>
+                  <p className="text-xs font-mono text-dark-300">{focusedCallsignInfo.grid}</p>
                 )}
                 {focusedCallsignInfo.bearing != null && (
-                  <p className="text-xs text-accent-info">
+                  <p className="text-xs font-mono text-accent-info">
                     {focusedCallsignInfo.bearing.toFixed(0)}°
                     {focusedCallsignInfo.distance != null && ` / ${Math.round(focusedCallsignInfo.distance)} km`}
                   </p>

--- a/src/Log4YM.Web/src/plugins/HeaderPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/HeaderPlugin.tsx
@@ -92,64 +92,64 @@ export function HeaderPlugin() {
   const localDateStr = `${days[currentTime.getDay()]}, ${months[currentTime.getMonth()]} ${currentTime.getDate()}`;
 
   return (
-    <div className="header-plugin">
+    <div className="header-plugin bg-dark-900">
       {/* Callsign + Version */}
       <div className="header-plugin__group">
-        <span className="header-plugin__callsign">{callsign || 'N0CALL'}</span>
-        <span className="header-plugin__version">v1.0.0</span>
+        <span className="header-plugin__callsign font-display text-accent-primary">{callsign || 'N0CALL'}</span>
+        <span className="header-plugin__version font-mono text-dark-300">v1.0.0</span>
       </div>
 
       {/* Separator */}
-      <div className="header-plugin__sep" />
+      <div className="header-plugin__sep border-glass-100" />
 
       {/* UTC Time */}
       <div className="header-plugin__group">
-        <span className="header-plugin__label">UTC</span>
-        <span className="header-plugin__time">
+        <span className="header-plugin__label font-ui text-accent-success">UTC</span>
+        <span className="header-plugin__time font-display text-accent-primary">
           {pad(utcHours)}:{pad(utcMinutes)}:{pad(utcSeconds)}
         </span>
-        <span className="header-plugin__date">{utcYear}-{utcMonth}-{utcDay}</span>
+        <span className="header-plugin__date font-mono text-dark-300">{utcYear}-{utcMonth}-{utcDay}</span>
       </div>
 
       {/* Separator */}
-      <div className="header-plugin__sep" />
+      <div className="header-plugin__sep border-glass-100" />
 
       {/* Local Time */}
       <div className="header-plugin__group">
-        <span className="header-plugin__label">LOCAL</span>
-        <span className="header-plugin__time">
+        <span className="header-plugin__label font-ui text-accent-success">LOCAL</span>
+        <span className="header-plugin__time font-display text-accent-primary">
           {pad(localHours)}:{pad(localMinutes)}:{pad(localSeconds)}
         </span>
-        <span className="header-plugin__date">{localDateStr}</span>
+        <span className="header-plugin__date font-mono text-dark-300">{localDateStr}</span>
       </div>
 
       {/* Separator */}
-      <div className="header-plugin__sep" />
+      <div className="header-plugin__sep border-glass-100" />
 
       {/* Weather */}
       {showWeather && weather && (
         <>
           <div className="header-plugin__group">
             <span className="header-plugin__weather-icon">{getWeatherIcon(weather.weatherCode)}</span>
-            <span className="header-plugin__weather-temp">
+            <span className="header-plugin__weather-temp font-mono text-accent-secondary">
               {weather.temperature}&deg;F/{weather.temperatureC}&deg;C
             </span>
           </div>
-          <div className="header-plugin__sep" />
+          <div className="header-plugin__sep border-glass-100" />
         </>
       )}
 
       {/* Space Weather Indices */}
       {spaceWeather && (
         <div className="header-plugin__group header-plugin__indices">
-          <span className="header-plugin__label">SFI</span>
-          <span className="header-plugin__value">{spaceWeather.solarFluxIndex}</span>
-          <span className="header-plugin__label" style={{ marginLeft: 12 }}>K</span>
-          <span className={`header-plugin__value${spaceWeather.kIndex >= 4 ? ' header-plugin__value--danger' : ''}`}>
+          <span className="header-plugin__label font-ui text-accent-success">SFI</span>
+          <span className="header-plugin__value font-display text-accent-primary">{spaceWeather.solarFluxIndex}</span>
+          <span className="header-plugin__label font-ui text-accent-success" style={{ marginLeft: 12 }}>K</span>
+          <span className={`header-plugin__value font-display${spaceWeather.kIndex >= 4 ? ' header-plugin__value--danger text-accent-danger' : ' text-accent-primary'}`}>
             {spaceWeather.kIndex}
           </span>
-          <span className="header-plugin__label" style={{ marginLeft: 12 }}>SSN</span>
-          <span className="header-plugin__value">{spaceWeather.sunspotNumber}</span>
+          <span className="header-plugin__label font-ui text-accent-success" style={{ marginLeft: 12 }}>SSN</span>
+          <span className="header-plugin__value font-display text-accent-primary">{spaceWeather.sunspotNumber}</span>
         </div>
       )}
     </div>

--- a/src/Log4YM.Web/src/plugins/LogEntryPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/LogEntryPlugin.tsx
@@ -231,10 +231,10 @@ export function LogEntryPlugin() {
         <button
           type="button"
           onClick={toggleFollowRadio}
-          className={`flex items-center gap-1.5 px-2 py-1 text-xs rounded transition-all ${
+          className={`flex items-center gap-1.5 px-2 py-1 text-xs font-ui rounded transition-all ${
             followRadio
               ? 'bg-accent-success/20 text-accent-success hover:bg-accent-success/30'
-              : 'bg-dark-600 text-gray-400 hover:bg-dark-500'
+              : 'bg-dark-600 text-dark-300 hover:bg-dark-500'
           }`}
           title={followRadio ? 'Following radio frequency' : 'Not following radio'}
         >
@@ -256,7 +256,7 @@ export function LogEntryPlugin() {
         {/* Callsign, Band, Mode on one line */}
         <div className="flex gap-2 items-end">
           <div className="flex-1">
-            <label className="text-xs text-gray-400 flex items-center gap-1 mb-1">
+            <label className="text-xs font-ui text-dark-300 flex items-center gap-1 mb-1">
               {isLookingUpCallsign ? (
                 <Loader2 className="w-3 h-3 animate-spin text-accent-primary" />
               ) : (
@@ -277,7 +277,7 @@ export function LogEntryPlugin() {
             />
           </div>
           <div className="w-28">
-            <label className="text-xs text-gray-400 mb-1 flex items-center gap-1">
+            <label className="text-xs font-ui text-dark-300 mb-1 flex items-center gap-1">
               Band
               {followRadio && currentRadioState && (
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-success" title="From radio" />
@@ -286,7 +286,7 @@ export function LogEntryPlugin() {
             <select
               value={formData.band}
               onChange={(e) => setFormData(prev => ({ ...prev, band: e.target.value }))}
-              className={`glass-input w-full text-sm ${
+              className={`glass-input w-full text-sm font-mono ${
                 followRadio && currentRadioState ? 'border-accent-success/30' : ''
               }`}
             >
@@ -296,7 +296,7 @@ export function LogEntryPlugin() {
             </select>
           </div>
           <div className="w-28">
-            <label className="text-xs text-gray-400 mb-1 flex items-center gap-1">
+            <label className="text-xs font-ui text-dark-300 mb-1 flex items-center gap-1">
               Mode
               {followRadio && currentRadioState && (
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-success" title="From radio" />
@@ -305,7 +305,7 @@ export function LogEntryPlugin() {
             <select
               value={formData.mode}
               onChange={(e) => setFormData(prev => ({ ...prev, mode: e.target.value }))}
-              className={`glass-input w-full text-sm ${
+              className={`glass-input w-full text-sm font-mono ${
                 followRadio && currentRadioState ? 'border-accent-success/30' : ''
               }`}
             >
@@ -324,7 +324,7 @@ export function LogEntryPlugin() {
                 <Loader2 className="w-5 h-5 text-accent-primary animate-spin" />
               </div>
               <div className="flex-1 min-w-0">
-                <p className="font-medium text-gray-400 text-sm">Looking up callsign...</p>
+                <p className="font-medium font-ui text-dark-300 text-sm">Looking up callsign...</p>
               </div>
             </div>
           </div>
@@ -343,15 +343,15 @@ export function LogEntryPlugin() {
                 />
               ) : (
                 <div className="w-10 h-10 rounded-lg bg-dark-600 flex items-center justify-center">
-                  <User className="w-5 h-5 text-gray-500" />
+                  <User className="w-5 h-5 text-dark-300" />
                 </div>
               )}
               <div className="flex-1 min-w-0">
                 <p className="font-medium text-gray-100 text-sm truncate">
                   {focusedCallsignInfo.name || 'No name on file'}
                 </p>
-                <div className="flex items-center gap-2 text-xs text-gray-400">
-                  <span>{getCountryFlag(focusedCallsignInfo.country) || '🏳️'}</span>
+                <div className="flex items-center gap-2 text-xs text-dark-300">
+                  <span>{getCountryFlag(focusedCallsignInfo.country) || ''}</span>
                   <span className="truncate">{focusedCallsignInfo.country || 'Unknown'}</span>
                   {focusedCallsignInfo.grid && (
                     <>
@@ -362,7 +362,7 @@ export function LogEntryPlugin() {
                 </div>
               </div>
               <div className="text-3xl" title={focusedCallsignInfo.country || 'Unknown country'}>
-                {getCountryFlag(focusedCallsignInfo.country, '🏳️')}
+                {getCountryFlag(focusedCallsignInfo.country, '')}
               </div>
             </div>
           </div>
@@ -370,7 +370,7 @@ export function LogEntryPlugin() {
 
         {/* Name field with lock pattern */}
         <div>
-          <label className="text-xs text-gray-400 mb-1 flex items-center gap-1">
+          <label className="text-xs font-ui text-dark-300 mb-1 flex items-center gap-1">
             <User className="w-3 h-3" />
             Name
             {nameLocked && focusedCallsignInfo?.name && (
@@ -393,8 +393,8 @@ export function LogEntryPlugin() {
               onClick={() => setNameLocked(!nameLocked)}
               className={`p-1.5 rounded transition-colors ${
                 nameLocked
-                  ? 'text-gray-500 hover:text-gray-300'
-                  : 'text-amber-400 hover:text-amber-300'
+                  ? 'text-dark-300 hover:text-dark-200'
+                  : 'text-accent-primary hover:text-accent-primary/80'
               }`}
               title={nameLocked ? 'Unlock to edit name' : 'Lock to auto-fill from QRZ'}
               tabIndex={-1}
@@ -407,7 +407,7 @@ export function LogEntryPlugin() {
         {/* Frequency, RST Sent, RST Rcvd on one line */}
         <div className="flex gap-3 items-end">
           <div className="w-28">
-            <label className="text-xs text-gray-400 mb-1 flex items-center gap-1">
+            <label className="text-xs font-ui text-dark-300 mb-1 flex items-center gap-1">
               Freq (kHz)
               {followRadio && currentRadioState && (
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-success" title="From radio" />
@@ -436,8 +436,8 @@ export function LogEntryPlugin() {
 
           {/* TX RST */}
           <div>
-            <label className="text-xs text-gray-400 mb-1 flex items-center gap-1">
-              <span className="text-green-400">TX</span> RST
+            <label className="text-xs font-ui text-dark-300 mb-1 flex items-center gap-1">
+              <span className="text-accent-success">TX</span> RST
             </label>
             <div className="flex items-center gap-1">
               <input
@@ -449,7 +449,7 @@ export function LogEntryPlugin() {
               />
               {formData.rstSent.endsWith('9') && (
                 <>
-                  <span className="text-gray-500">+</span>
+                  <span className="text-dark-300">+</span>
                   <select
                     value={formData.rstSentPlus}
                     onChange={(e) => setFormData(prev => ({ ...prev, rstSentPlus: e.target.value }))}
@@ -468,13 +468,13 @@ export function LogEntryPlugin() {
 
           {/* Separator */}
           <div className="flex items-end pb-2">
-            <span className="text-gray-600 text-lg">/</span>
+            <span className="text-dark-600 text-lg">/</span>
           </div>
 
           {/* RX RST */}
           <div>
-            <label className="text-xs text-gray-400 mb-1 flex items-center gap-1">
-              <span className="text-blue-400">RX</span> RST
+            <label className="text-xs font-ui text-dark-300 mb-1 flex items-center gap-1">
+              <span className="text-accent-secondary">RX</span> RST
             </label>
             <div className="flex items-center gap-1">
               <input
@@ -486,7 +486,7 @@ export function LogEntryPlugin() {
               />
               {formData.rstRcvd.endsWith('9') && (
                 <>
-                  <span className="text-gray-500">+</span>
+                  <span className="text-dark-300">+</span>
                   <select
                     value={formData.rstRcvdPlus}
                     onChange={(e) => setFormData(prev => ({ ...prev, rstRcvdPlus: e.target.value }))}
@@ -506,7 +506,7 @@ export function LogEntryPlugin() {
 
         {/* Comment */}
         <div>
-          <label className="text-xs text-gray-400 mb-1 block">Comment</label>
+          <label className="text-xs font-ui text-dark-300 mb-1 block">Comment</label>
           <input
             type="text"
             value={formData.comment}
@@ -518,7 +518,7 @@ export function LogEntryPlugin() {
 
         {/* Notes */}
         <div>
-          <label className="text-xs text-gray-400 mb-1 block">Notes</label>
+          <label className="text-xs font-ui text-dark-300 mb-1 block">Notes</label>
           <input
             type="text"
             value={formData.notes}
@@ -529,7 +529,7 @@ export function LogEntryPlugin() {
         </div>
 
         {/* Timestamp - compact display with optional edit */}
-        <div className="flex items-center gap-2 text-xs text-gray-400">
+        <div className="flex items-center gap-2 text-xs text-dark-300">
           <Clock className="w-3 h-3" />
           {timeLocked ? (
             <>
@@ -537,7 +537,7 @@ export function LogEntryPlugin() {
               <button
                 type="button"
                 onClick={() => setTimeLocked(false)}
-                className="text-gray-500 hover:text-gray-300 transition-colors"
+                className="text-dark-300 hover:text-dark-200 transition-colors"
                 title="Edit timestamp"
                 tabIndex={-1}
               >
@@ -562,7 +562,7 @@ export function LogEntryPlugin() {
               <button
                 type="button"
                 onClick={() => setTimeLocked(true)}
-                className="text-amber-400 hover:text-amber-300 transition-colors"
+                className="text-accent-primary hover:text-accent-primary/80 transition-colors"
                 title="Lock to system time"
                 tabIndex={-1}
               >

--- a/src/Log4YM.Web/src/plugins/LogHistoryPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/LogHistoryPlugin.tsx
@@ -21,7 +21,7 @@ const ModeCellRenderer = (props: ICellRendererParams<QsoResponse>) => {
       case 'FT4': return 'badge-ft8';
       case 'RTTY':
       case 'PSK31': return 'badge-rtty';
-      default: return 'bg-dark-600 text-gray-300';
+      default: return 'bg-dark-600 text-dark-200';
     }
   };
   return <span className={`badge text-xs ${getModeClass(mode)}`}>{mode}</span>;
@@ -49,9 +49,9 @@ const DateCellRenderer = (props: ICellRendererParams<QsoResponse>) => {
     });
   };
   return (
-    <div className="flex items-center gap-1 text-gray-400">
+    <div className="flex items-center gap-1 text-dark-300">
       <Calendar className="w-3 h-3" />
-      {formatDate(props.value)}
+      <span className="font-mono">{formatDate(props.value)}</span>
     </div>
   );
 };
@@ -66,14 +66,14 @@ const ActionCellRenderer = (props: ICellRendererParams<QsoResponse> & {
     <div className="flex items-center gap-1">
       <button
         onClick={() => props.onEdit(props.data!)}
-        className="p-1 text-gray-400 hover:text-accent-primary transition-colors"
+        className="p-1 text-dark-300 hover:text-accent-primary transition-colors"
         title="Edit QSO"
       >
         <Pencil className="w-3.5 h-3.5" />
       </button>
       <button
         onClick={() => props.onDelete(props.data!)}
-        className="p-1 text-gray-400 hover:text-red-400 transition-colors"
+        className="p-1 text-dark-300 hover:text-accent-danger transition-colors"
         title="Delete QSO"
       >
         <Trash2 className="w-3.5 h-3.5" />
@@ -262,7 +262,7 @@ export function LogHistoryPlugin() {
       headerName: 'Time',
       field: 'timeOn',
       valueFormatter: (params) => formatTime(params.value),
-      cellClass: 'font-mono text-gray-400',
+      cellClass: 'font-mono text-dark-300',
       width: 70,
       resizable: true,
     },
@@ -290,14 +290,14 @@ export function LogHistoryPlugin() {
     {
       headerName: 'RST S/R',
       valueGetter: (params) => `${params.data?.rstSent || '-'}/${params.data?.rstRcvd || '-'}`,
-      cellClass: 'font-mono text-gray-400',
+      cellClass: 'font-mono text-dark-300',
       width: 80,
       resizable: true,
     },
     {
       headerName: 'Name',
       valueGetter: (params) => params.data?.station?.name || params.data?.name || '-',
-      cellClass: 'text-gray-300',
+      cellClass: 'text-dark-200',
       width: 120,
       resizable: true,
     },
@@ -312,7 +312,7 @@ export function LogHistoryPlugin() {
     {
       headerName: 'Country',
       valueGetter: (params) => params.data?.station?.country || params.data?.country || '-',
-      cellClass: 'text-gray-400',
+      cellClass: 'text-dark-300',
       width: 120,
       resizable: true,
     },
@@ -341,7 +341,7 @@ export function LogHistoryPlugin() {
       title="Log History"
       icon={<Book className="w-5 h-5" />}
       actions={
-        <div className="flex items-center gap-3 text-sm text-gray-400">
+        <div className="flex items-center gap-3 text-sm text-dark-300 font-ui">
           <span>
             {stats?.totalQsos.toLocaleString() || 0}
             {hasActiveFilters && totalCount !== stats?.totalQsos && (
@@ -398,13 +398,13 @@ export function LogHistoryPlugin() {
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Loader2 className="w-4 h-4 text-accent-info animate-spin" />
-                <span className="text-sm text-gray-300">
+                <span className="text-sm text-dark-200 font-ui">
                   Connecting to QRZ.com...
                 </span>
               </div>
               <button
                 onClick={handleCancelSync}
-                className="text-xs text-red-400 hover:text-red-300 flex items-center gap-1 px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
+                className="text-xs text-accent-danger hover:text-accent-danger/80 flex items-center gap-1 px-2 py-1 rounded hover:bg-accent-danger/10 transition-colors"
                 title="Cancel sync"
               >
                 <X className="w-3 h-3" />
@@ -420,17 +420,17 @@ export function LogHistoryPlugin() {
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
                 <Loader2 className="w-4 h-4 text-accent-info animate-spin" />
-                <span className="text-sm text-gray-300">
+                <span className="text-sm text-dark-200 font-ui">
                   {qrzSyncProgress.message || `Syncing to QRZ.com...`}
                 </span>
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-dark-300 font-mono">
                   {qrzSyncProgress.completed} / {qrzSyncProgress.total}
                 </span>
                 <button
                   onClick={handleCancelSync}
-                  className="text-xs text-red-400 hover:text-red-300 flex items-center gap-1 px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
+                  className="text-xs text-accent-danger hover:text-accent-danger/80 flex items-center gap-1 px-2 py-1 rounded hover:bg-accent-danger/10 transition-colors"
                   title="Cancel sync"
                 >
                   <X className="w-3 h-3" />
@@ -444,10 +444,10 @@ export function LogHistoryPlugin() {
                 style={{ width: `${(qrzSyncProgress.completed / qrzSyncProgress.total) * 100}%` }}
               />
             </div>
-            <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <div className="flex justify-between text-xs text-dark-300 mt-1 font-mono">
               <span className="text-accent-success">{qrzSyncProgress.successful} successful</span>
               {qrzSyncProgress.failed > 0 && (
-                <span className="text-accent-error">{qrzSyncProgress.failed} failed</span>
+                <span className="text-accent-danger">{qrzSyncProgress.failed} failed</span>
               )}
             </div>
           </div>
@@ -457,17 +457,17 @@ export function LogHistoryPlugin() {
         {qrzSyncProgress?.isComplete && (
           <div className={`bg-dark-700/80 rounded-lg p-3 border ${
             qrzSyncProgress.message?.includes('cancelled')
-              ? 'border-yellow-500/30'
+              ? 'border-accent-primary/30'
               : 'border-accent-success/30'
           }`}>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <CloudUpload className={`w-4 h-4 ${
                   qrzSyncProgress.message?.includes('cancelled')
-                    ? 'text-yellow-400'
+                    ? 'text-accent-primary'
                     : 'text-accent-success'
                 }`} />
-                <span className="text-sm text-gray-300">
+                <span className="text-sm text-dark-200 font-ui">
                   {qrzSyncProgress.message?.includes('cancelled')
                     ? `Sync cancelled: ${qrzSyncProgress.successful} of ${qrzSyncProgress.total} uploaded`
                     : qrzSyncProgress.total === 0
@@ -478,7 +478,7 @@ export function LogHistoryPlugin() {
               </div>
               <button
                 onClick={() => setQrzSyncProgress(null)}
-                className="text-gray-500 hover:text-gray-300"
+                className="text-dark-300 hover:text-dark-200"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -493,38 +493,38 @@ export function LogHistoryPlugin() {
               onClick={() => setShowSummary(!showSummary)}
               className="w-full flex items-center justify-between p-3 hover:bg-dark-600/50 transition-colors"
             >
-              <div className="flex items-center gap-2 text-sm text-gray-300">
+              <div className="flex items-center gap-2 text-sm text-dark-200 font-ui">
                 <span className="font-medium">Summary</span>
-                <span className="text-gray-500">|</span>
-                <span className="text-accent-primary font-bold">{stats.totalQsos.toLocaleString()}</span>
+                <span className="text-dark-300">|</span>
+                <span className="text-accent-primary font-display font-bold">{stats.totalQsos.toLocaleString()}</span>
                 {hasActiveFilters && totalCount !== stats.totalQsos && (
-                  <span className="text-accent-info font-bold">({totalCount.toLocaleString()})</span>
+                  <span className="text-accent-info font-display font-bold">({totalCount.toLocaleString()})</span>
                 )}
-                <span className="text-gray-500">QSOs</span>
+                <span className="text-dark-300">QSOs</span>
               </div>
               {showSummary ? (
-                <ChevronUp className="w-4 h-4 text-gray-400" />
+                <ChevronUp className="w-4 h-4 text-dark-300" />
               ) : (
-                <ChevronDown className="w-4 h-4 text-gray-400" />
+                <ChevronDown className="w-4 h-4 text-dark-300" />
               )}
             </button>
             {showSummary && (
               <div className="grid grid-cols-4 gap-4 p-4 pt-2 border-t border-glass-100">
                 <div className="text-center">
-                  <p className="text-2xl font-bold text-accent-primary">{stats.totalQsos.toLocaleString()}</p>
-                  <p className="text-xs text-gray-500">Total QSOs</p>
+                  <p className="text-2xl font-display font-bold text-accent-primary">{stats.totalQsos.toLocaleString()}</p>
+                  <p className="text-xs text-dark-300 font-ui">Total QSOs</p>
                 </div>
                 <div className="text-center">
-                  <p className="text-2xl font-bold text-accent-success">{stats.uniqueCountries}</p>
-                  <p className="text-xs text-gray-500">Countries</p>
+                  <p className="text-2xl font-display font-bold text-accent-success">{stats.uniqueCountries}</p>
+                  <p className="text-xs text-dark-300 font-ui">Countries</p>
                 </div>
                 <div className="text-center">
-                  <p className="text-2xl font-bold text-accent-info">{stats.uniqueGrids}</p>
-                  <p className="text-xs text-gray-500">Grids</p>
+                  <p className="text-2xl font-display font-bold text-accent-info">{stats.uniqueGrids}</p>
+                  <p className="text-xs text-dark-300 font-ui">Grids</p>
                 </div>
                 <div className="text-center">
-                  <p className="text-2xl font-bold text-accent-warning">{stats.qsosToday}</p>
-                  <p className="text-xs text-gray-500">Today</p>
+                  <p className="text-2xl font-display font-bold text-accent-warning">{stats.qsosToday}</p>
+                  <p className="text-xs text-dark-300 font-ui">Today</p>
                 </div>
               </div>
             )}
@@ -535,7 +535,7 @@ export function LogHistoryPlugin() {
         <div className="flex gap-3 flex-wrap">
           {/* Callsign Search */}
           <div className="flex-1 min-w-[150px] relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-dark-300" />
             <input
               type="text"
               value={callsignSearch}
@@ -550,7 +550,7 @@ export function LogHistoryPlugin() {
 
           {/* Name Search */}
           <div className="flex-1 min-w-[150px] relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-dark-300" />
             <input
               type="text"
               value={nameSearch}
@@ -570,7 +570,7 @@ export function LogHistoryPlugin() {
               setSelectedBand(e.target.value);
               setCurrentPage(1);
             }}
-            className="glass-input w-24"
+            className="glass-input w-24 font-mono"
           >
             <option value="">Band</option>
             <option value="160m">160m</option>
@@ -593,7 +593,7 @@ export function LogHistoryPlugin() {
               setSelectedMode(e.target.value);
               setCurrentPage(1);
             }}
-            className="glass-input w-24"
+            className="glass-input w-24 font-mono"
           >
             <option value="">Mode</option>
             <option value="SSB">SSB</option>
@@ -619,7 +619,7 @@ export function LogHistoryPlugin() {
           {hasActiveFilters && (
             <button
               onClick={clearFilters}
-              className="glass-button p-2 text-red-400 hover:text-red-300"
+              className="glass-button p-2 text-accent-danger hover:text-accent-danger/80"
               title="Clear all filters"
             >
               <X className="w-4 h-4" />
@@ -630,9 +630,9 @@ export function LogHistoryPlugin() {
         {/* Date Range Filters (Collapsible) */}
         {showFilters && (
           <div className="flex gap-3 items-center p-3 bg-dark-700/50 rounded-lg">
-            <Calendar className="w-4 h-4 text-gray-500" />
+            <Calendar className="w-4 h-4 text-dark-300" />
             <div className="flex items-center gap-2">
-              <label className="text-sm text-gray-400">From:</label>
+              <label className="text-sm text-dark-300 font-ui">From:</label>
               <input
                 type="date"
                 value={fromDate}
@@ -640,11 +640,11 @@ export function LogHistoryPlugin() {
                   setFromDate(e.target.value);
                   setCurrentPage(1);
                 }}
-                className="glass-input px-2 py-1 text-sm"
+                className="glass-input px-2 py-1 text-sm font-mono"
               />
             </div>
             <div className="flex items-center gap-2">
-              <label className="text-sm text-gray-400">To:</label>
+              <label className="text-sm text-dark-300 font-ui">To:</label>
               <input
                 type="date"
                 value={toDate}
@@ -652,7 +652,7 @@ export function LogHistoryPlugin() {
                   setToDate(e.target.value);
                   setCurrentPage(1);
                 }}
-                className="glass-input px-2 py-1 text-sm"
+                className="glass-input px-2 py-1 text-sm font-mono"
               />
             </div>
           </div>
@@ -661,7 +661,7 @@ export function LogHistoryPlugin() {
         {/* AG Grid Table */}
         <div className="ag-theme-alpine-dark h-[calc(100vh-380px)]">
           {isLoading ? (
-            <div className="flex items-center justify-center py-8 text-gray-500">
+            <div className="flex items-center justify-center py-8 text-dark-300">
               <Radio className="w-4 h-4 animate-spin mr-2" />
               Loading...
             </div>
@@ -683,7 +683,7 @@ export function LogHistoryPlugin() {
         {/* Pagination */}
         {totalPages > 1 && (
           <div className="flex items-center justify-between pt-2 border-t border-glass-100">
-            <div className="text-sm text-gray-400">
+            <div className="text-sm text-dark-300 font-mono">
               Showing {((currentPage - 1) * pageSize) + 1} - {Math.min(currentPage * pageSize, totalCount)} of {totalCount.toLocaleString()}
             </div>
             <div className="flex items-center gap-1">
@@ -713,9 +713,9 @@ export function LogHistoryPlugin() {
                   }}
                   min={1}
                   max={totalPages}
-                  className="glass-input w-16 text-center text-sm py-1"
+                  className="glass-input w-16 text-center text-sm py-1 font-mono"
                 />
-                <span className="text-gray-400 text-sm">/ {totalPages}</span>
+                <span className="text-dark-300 text-sm font-mono">/ {totalPages}</span>
               </div>
               <button
                 onClick={() => handlePageChange(currentPage + 1)}
@@ -752,18 +752,18 @@ export function LogHistoryPlugin() {
       {/* Delete Confirmation Modal */}
       {deletingQso && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-dark-800 rounded-lg p-6 max-w-md w-full mx-4 border border-glass-100">
-            <h3 className="text-lg font-semibold text-white mb-4">Delete QSO?</h3>
-            <p className="text-gray-400 mb-2">
+          <div className="bg-dark-800 rounded-lg p-6 max-w-md w-full mx-4 border border-glass-200">
+            <h3 className="text-lg font-ui font-semibold text-white mb-4">Delete QSO?</h3>
+            <p className="text-dark-300 mb-2">
               Are you sure you want to delete this QSO?
             </p>
             <div className="bg-dark-700/50 rounded p-3 mb-6">
               <p className="text-accent-primary font-mono font-bold">{deletingQso.callsign}</p>
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-dark-300 font-mono">
                 {new Date(deletingQso.qsoDate).toLocaleDateString()} • {deletingQso.band} • {deletingQso.mode}
               </p>
             </div>
-            <p className="text-sm text-red-400 mb-4">
+            <p className="text-sm text-accent-danger mb-4">
               This action cannot be undone.
             </p>
             <div className="flex gap-3 justify-end">
@@ -777,7 +777,7 @@ export function LogHistoryPlugin() {
               <button
                 onClick={handleDelete}
                 disabled={isDeleting}
-                className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 disabled:opacity-50"
+                className="bg-accent-danger hover:bg-accent-danger/80 text-white px-4 py-2 rounded-lg flex items-center gap-2 disabled:opacity-50"
               >
                 {isDeleting ? (
                   <Loader2 className="w-4 h-4 animate-spin" />
@@ -794,21 +794,21 @@ export function LogHistoryPlugin() {
       {/* ADIF Import Modal */}
       {showImportModal && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-dark-800 rounded-lg p-6 max-w-lg w-full mx-4 border border-glass-100">
+          <div className="bg-dark-800 rounded-lg p-6 max-w-lg w-full mx-4 border border-glass-200">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+              <h3 className="text-lg font-ui font-semibold text-white flex items-center gap-2">
                 <Upload className="w-5 h-5 text-accent-success" />
                 Import ADIF
               </h3>
               <button
                 onClick={() => setShowImportModal(false)}
-                className="text-gray-400 hover:text-white"
+                className="text-dark-300 hover:text-white"
               >
                 <X className="w-5 h-5" />
               </button>
             </div>
 
-            <p className="text-sm text-gray-400 mb-4">
+            <p className="text-sm text-dark-300 mb-4">
               Import QSOs from an ADIF file. Supports .adi, .adif, and .xml formats.
             </p>
 
@@ -819,11 +819,11 @@ export function LogHistoryPlugin() {
                   type="checkbox"
                   checked={markAsSyncedToQrz}
                   onChange={e => setMarkAsSyncedToQrz(e.target.checked)}
-                  className="w-4 h-4 rounded border-gray-600 text-accent-primary focus:ring-accent-primary"
+                  className="w-4 h-4 rounded border-glass-200 text-accent-primary focus:ring-accent-primary/40"
                 />
                 <div>
-                  <p className="text-sm text-gray-200">Mark as already synced to QRZ</p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-sm text-dark-200 font-ui">Mark as already synced to QRZ</p>
+                  <p className="text-xs text-dark-300">
                     Recommended when importing from QRZ.com export (prevents re-uploading)
                   </p>
                 </div>
@@ -834,26 +834,26 @@ export function LogHistoryPlugin() {
                   type="checkbox"
                   checked={skipDuplicates}
                   onChange={e => setSkipDuplicates(e.target.checked)}
-                  className="w-4 h-4 rounded border-gray-600 text-accent-primary focus:ring-accent-primary"
+                  className="w-4 h-4 rounded border-glass-200 text-accent-primary focus:ring-accent-primary/40"
                 />
                 <div>
-                  <p className="text-sm text-gray-200">Skip duplicate QSOs</p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-sm text-dark-200 font-ui">Skip duplicate QSOs</p>
+                  <p className="text-xs text-dark-300">
                     Skip QSOs that match existing records (callsign, date, time, band, mode)
                   </p>
                 </div>
               </label>
 
-              <label className="flex items-center gap-3 p-3 bg-red-500/10 border border-red-500/30 rounded-lg cursor-pointer hover:bg-red-500/20">
+              <label className="flex items-center gap-3 p-3 bg-accent-danger/10 border border-accent-danger/30 rounded-lg cursor-pointer hover:bg-accent-danger/20">
                 <input
                   type="checkbox"
                   checked={clearExistingLogs}
                   onChange={e => setClearExistingLogs(e.target.checked)}
-                  className="w-4 h-4 rounded border-red-600 text-red-500 focus:ring-red-500"
+                  className="w-4 h-4 rounded border-accent-danger/30 text-accent-danger focus:ring-accent-danger/40"
                 />
                 <div>
-                  <p className="text-sm text-red-400">Clear existing log before import</p>
-                  <p className="text-xs text-red-400/70">
+                  <p className="text-sm text-accent-danger font-ui">Clear existing log before import</p>
+                  <p className="text-xs text-accent-danger/70">
                     Warning: This will delete ALL existing QSOs before importing
                   </p>
                 </div>
@@ -901,41 +901,41 @@ export function LogHistoryPlugin() {
       {/* Import Results */}
       {importResult && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-dark-800 rounded-lg p-6 max-w-md w-full mx-4 border border-glass-100">
-            <h3 className="text-lg font-semibold text-white flex items-center gap-2 mb-4">
+          <div className="bg-dark-800 rounded-lg p-6 max-w-md w-full mx-4 border border-glass-200">
+            <h3 className="text-lg font-ui font-semibold text-white flex items-center gap-2 mb-4">
               {importResult.errorCount === 0 && importResult.importedCount > 0 ? (
-                <CheckCircle className="w-5 h-5 text-green-400" />
+                <CheckCircle className="w-5 h-5 text-accent-success" />
               ) : importResult.errorCount > 0 ? (
-                <AlertTriangle className="w-5 h-5 text-yellow-400" />
+                <AlertTriangle className="w-5 h-5 text-accent-primary" />
               ) : (
-                <XCircle className="w-5 h-5 text-red-400" />
+                <XCircle className="w-5 h-5 text-accent-danger" />
               )}
               Import Results
             </h3>
 
             <div className="grid grid-cols-4 gap-4 mb-4">
               <div className="text-center">
-                <p className="text-2xl font-bold text-accent-primary">{importResult.totalRecords}</p>
-                <p className="text-xs text-gray-500">Total</p>
+                <p className="text-2xl font-display font-bold text-accent-primary">{importResult.totalRecords}</p>
+                <p className="text-xs text-dark-300 font-ui">Total</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold text-green-400">{importResult.importedCount}</p>
-                <p className="text-xs text-gray-500">Imported</p>
+                <p className="text-2xl font-display font-bold text-accent-success">{importResult.importedCount}</p>
+                <p className="text-xs text-dark-300 font-ui">Imported</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold text-yellow-400">{importResult.skippedDuplicates}</p>
-                <p className="text-xs text-gray-500">Duplicates</p>
+                <p className="text-2xl font-display font-bold text-accent-primary">{importResult.skippedDuplicates}</p>
+                <p className="text-xs text-dark-300 font-ui">Duplicates</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold text-red-400">{importResult.errorCount}</p>
-                <p className="text-xs text-gray-500">Errors</p>
+                <p className="text-2xl font-display font-bold text-accent-danger">{importResult.errorCount}</p>
+                <p className="text-xs text-dark-300 font-ui">Errors</p>
               </div>
             </div>
 
             {importResult.errors.length > 0 && (
               <div className="max-h-24 overflow-auto bg-dark-700/50 rounded p-2 mb-4">
                 {importResult.errors.map((error, i) => (
-                  <p key={i} className="text-sm text-red-400 flex items-start gap-2 py-1">
+                  <p key={i} className="text-sm text-accent-danger flex items-start gap-2 py-1">
                     <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                     {error}
                   </p>
@@ -1003,13 +1003,13 @@ function EditQsoModal({
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-      <div className="bg-dark-800 rounded-lg p-6 max-w-2xl w-full mx-4 border border-glass-100 max-h-[90vh] overflow-y-auto">
-        <h3 className="text-lg font-semibold text-white mb-4">Edit QSO</h3>
+      <div className="bg-dark-800 rounded-lg p-6 max-w-2xl w-full mx-4 border border-glass-200 max-h-[90vh] overflow-y-auto">
+        <h3 className="text-lg font-ui font-semibold text-white mb-4">Edit QSO</h3>
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Row 1: Callsign, Date, Time */}
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Callsign</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Callsign</label>
               <input
                 type="text"
                 value={formData.callsign}
@@ -1019,17 +1019,17 @@ function EditQsoModal({
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Date</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Date</label>
               <input
                 type="date"
                 value={formData.qsoDate}
                 onChange={(e) => setFormData({ ...formData, qsoDate: e.target.value })}
-                className="glass-input w-full"
+                className="glass-input w-full font-mono"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Time (UTC)</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Time (UTC)</label>
               <input
                 type="text"
                 value={formData.timeOn}
@@ -1044,11 +1044,11 @@ function EditQsoModal({
           {/* Row 2: Band, Mode, Frequency */}
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Band</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Band</label>
               <select
                 value={formData.band}
                 onChange={(e) => setFormData({ ...formData, band: e.target.value })}
-                className="glass-input w-full"
+                className="glass-input w-full font-mono"
                 required
               >
                 <option value="">Select</option>
@@ -1066,11 +1066,11 @@ function EditQsoModal({
               </select>
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Mode</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Mode</label>
               <select
                 value={formData.mode}
                 onChange={(e) => setFormData({ ...formData, mode: e.target.value })}
-                className="glass-input w-full"
+                className="glass-input w-full font-mono"
                 required
               >
                 <option value="">Select</option>
@@ -1085,7 +1085,7 @@ function EditQsoModal({
               </select>
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Frequency (MHz)</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Frequency (MHz)</label>
               <input
                 type="number"
                 step="0.001"
@@ -1100,7 +1100,7 @@ function EditQsoModal({
           {/* Row 3: RST Sent, RST Rcvd */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm text-gray-400 mb-1">RST Sent</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">RST Sent</label>
               <input
                 type="text"
                 value={formData.rstSent}
@@ -1110,7 +1110,7 @@ function EditQsoModal({
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">RST Rcvd</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">RST Rcvd</label>
               <input
                 type="text"
                 value={formData.rstRcvd}
@@ -1124,7 +1124,7 @@ function EditQsoModal({
           {/* Row 4: Name, Grid, Country */}
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Name</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Name</label>
               <input
                 type="text"
                 value={formData.name}
@@ -1133,7 +1133,7 @@ function EditQsoModal({
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Grid</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Grid</label>
               <input
                 type="text"
                 value={formData.grid}
@@ -1143,7 +1143,7 @@ function EditQsoModal({
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Country</label>
+              <label className="block text-sm text-dark-300 mb-1 font-ui">Country</label>
               <input
                 type="text"
                 value={formData.country}
@@ -1155,7 +1155,7 @@ function EditQsoModal({
 
           {/* Row 5: Comment */}
           <div>
-            <label className="block text-sm text-gray-400 mb-1">Comment</label>
+            <label className="block text-sm text-dark-300 mb-1 font-ui">Comment</label>
             <textarea
               value={formData.comment}
               onChange={(e) => setFormData({ ...formData, comment: e.target.value })}

--- a/src/Log4YM.Web/src/plugins/MapPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/MapPlugin.tsx
@@ -29,10 +29,10 @@ const stationIcon = new L.DivIcon({
     <div style="
       width: 24px;
       height: 24px;
-      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      background: linear-gradient(135deg, #00ddff, #00bbdd);
       border: 3px solid #fff;
       border-radius: 50%;
-      box-shadow: 0 0 10px rgba(99, 102, 241, 0.6);
+      box-shadow: 0 0 10px rgba(0, 221, 255, 0.6);
     "></div>
   `,
   iconSize: [24, 24],
@@ -46,10 +46,10 @@ const targetIcon = new L.DivIcon({
     <div style="
       width: 20px;
       height: 20px;
-      background: linear-gradient(135deg, #f59e0b, #ef4444);
+      background: linear-gradient(135deg, #ffb432, #ff4466);
       border: 2px solid #fff;
       border-radius: 50%;
-      box-shadow: 0 0 8px rgba(245, 158, 11, 0.6);
+      box-shadow: 0 0 8px rgba(255, 180, 50, 0.6);
     "></div>
   `,
   iconSize: [20, 20],
@@ -166,12 +166,12 @@ export function MapPlugin() {
   // Station coordinates - prioritize lat/lon from settings, fall back to grid square, then defaults
   let stationLat = DEFAULT_LAT;
   let stationLon = DEFAULT_LON;
-  
+
   // First priority: explicit lat/lon in settings
   if (settings.station.latitude != null && settings.station.longitude != null) {
     stationLat = settings.station.latitude;
     stationLon = settings.station.longitude;
-  } 
+  }
   // Second priority: convert grid square to coordinates
   else if (settings.station.gridSquare) {
     const coords = gridToLatLon(settings.station.gridSquare);
@@ -256,14 +256,14 @@ export function MapPlugin() {
     setIsFullscreen(!isFullscreen);
   }, [isFullscreen]);
 
-  // Generate rotator beam visualization line (indigo)
+  // Generate rotator beam visualization line (cyan)
   const beamLinePoints: [number, number][] = [];
   const beamDistance = 5000; // 5000km beam visualization
   for (let d = 0; d <= beamDistance; d += 100) {
     beamLinePoints.push(getDestinationPoint(stationLat, stationLon, currentAzimuth, d));
   }
 
-  // Generate target heading line (orange) - separate from rotator beam
+  // Generate target heading line (amber) - separate from rotator beam
   const targetBearing = focusedCallsignInfo?.bearing;
   const targetLinePoints: [number, number][] = [];
   if (targetBearing != null) {
@@ -285,7 +285,7 @@ export function MapPlugin() {
           {rotatorEnabled ? (
             <span className="text-sm font-mono text-accent-primary">{currentAzimuth}°</span>
           ) : (
-            <span className="text-sm text-gray-500">No Rotator</span>
+            <span className="text-sm font-ui text-dark-300">No Rotator</span>
           )}
           <button
             onClick={toggleFullscreen}
@@ -302,7 +302,7 @@ export function MapPlugin() {
           center={[stationLat, stationLon]}
           zoom={5}
           className="w-full h-full"
-          style={{ background: '#1e1e1e' }}
+          style={{ background: '#0a0e14' }}
           ref={(map) => { mapRef.current = map ?? null; }}
           zoomControl={false}
         >
@@ -322,9 +322,9 @@ export function MapPlugin() {
           <Marker position={[stationLat, stationLon]} icon={stationIcon}>
             <Popup>
               <div className="text-center">
-                <strong className="text-accent-primary">{stationGrid || 'Station'}</strong>
+                <strong style={{ color: '#ffb432' }} className="font-mono">{stationGrid || 'Station'}</strong>
                 <br />
-                <span className="text-xs text-gray-500">Your Location</span>
+                <span className="text-xs font-ui" style={{ color: '#5a7090' }}>Your Location</span>
               </div>
             </Popup>
           </Marker>
@@ -334,20 +334,20 @@ export function MapPlugin() {
             center={[stationLat, stationLon]}
             radius={500000}
             pathOptions={{
-              color: '#6366f1',
-              fillColor: '#6366f1',
+              color: '#00ddff',
+              fillColor: '#00ddff',
               fillOpacity: 0.05,
               weight: 1,
               dashArray: '5, 5',
             }}
           />
 
-          {/* Rotator beam direction line - only show when rotator enabled (indigo) */}
+          {/* Rotator beam direction line - only show when rotator enabled (cyan) */}
           {rotatorEnabled && (
             <Polyline
               positions={beamLinePoints}
               pathOptions={{
-                color: '#6366f1',
+                color: '#00ddff',
                 weight: 3,
                 opacity: 0.7,
                 dashArray: '10, 5',
@@ -355,12 +355,12 @@ export function MapPlugin() {
             />
           )}
 
-          {/* Target heading line - show when we have a focused callsign with bearing (orange) */}
+          {/* Target heading line - show when we have a focused callsign with bearing (amber) */}
           {targetLinePoints.length > 0 && (
             <Polyline
               positions={targetLinePoints}
               pathOptions={{
-                color: '#f97316',
+                color: '#ffb432',
                 weight: 2,
                 opacity: 0.8,
                 dashArray: '5, 10',
@@ -373,15 +373,15 @@ export function MapPlugin() {
             <Marker position={[targetLat, targetLon]} icon={targetIcon}>
               <Popup>
                 <div className="text-center">
-                  <strong className="text-accent-warning">{focusedCallsignInfo?.callsign}</strong>
+                  <strong style={{ color: '#ffb432' }} className="font-mono">{focusedCallsignInfo?.callsign}</strong>
                   <br />
                   {focusedCallsignInfo?.grid && (
-                    <span className="text-xs">{focusedCallsignInfo.grid}</span>
+                    <span className="text-xs font-mono" style={{ color: '#8899aa' }}>{focusedCallsignInfo.grid}</span>
                   )}
                   {focusedCallsignInfo?.bearing != null && (
                     <>
                       <br />
-                      <span className="text-xs text-accent-info">
+                      <span className="text-xs font-mono" style={{ color: '#00ddff' }}>
                         {focusedCallsignInfo.bearing.toFixed(0)}° / {Math.round(focusedCallsignInfo.distance ?? 0)} km
                       </span>
                     </>
@@ -436,8 +436,8 @@ export function MapPlugin() {
                       saveSettings();
                       setShowLayerPicker(false);
                     }}
-                    className={`w-full text-left px-2 py-1 text-sm rounded hover:bg-dark-600 ${
-                      tileLayer === key ? 'text-accent-primary' : 'text-gray-300'
+                    className={`w-full text-left px-2 py-1 text-sm font-ui rounded hover:bg-dark-600 ${
+                      tileLayer === key ? 'text-accent-primary' : 'text-dark-200'
                     }`}
                   >
                     {layer.name}
@@ -462,16 +462,16 @@ export function MapPlugin() {
         {focusedCallsignInfo && (
           <div className="absolute top-4 left-4 glass-panel px-3 py-2 z-[1000]">
             <div className="flex items-center gap-2">
-              <Target className="w-4 h-4 text-accent-warning" />
+              <Target className="w-4 h-4 text-accent-primary" />
               <div>
                 <p className="font-mono font-bold text-accent-primary">
                   {focusedCallsignInfo.callsign}
                 </p>
                 {focusedCallsignInfo.grid && (
-                  <p className="text-xs text-gray-400">{focusedCallsignInfo.grid}</p>
+                  <p className="text-xs font-mono text-dark-300">{focusedCallsignInfo.grid}</p>
                 )}
                 {focusedCallsignInfo.bearing != null && (
-                  <p className="text-xs text-accent-info">
+                  <p className="text-xs font-mono text-accent-secondary">
                     {focusedCallsignInfo.bearing.toFixed(0)}°
                     {focusedCallsignInfo.distance != null && ` / ${Math.round(focusedCallsignInfo.distance)} km`}
                   </p>
@@ -482,7 +482,7 @@ export function MapPlugin() {
         )}
 
         {/* Instructions overlay */}
-        <div className="absolute bottom-4 right-4 glass-panel px-3 py-2 z-[1000] text-xs text-gray-400">
+        <div className="absolute bottom-4 right-4 glass-panel px-3 py-2 z-[1000] text-xs font-ui text-dark-300">
           {rotatorEnabled ? 'Click on map to set bearing' : 'Rotator disabled'}
         </div>
       </div>

--- a/src/Log4YM.Web/src/plugins/PgxlPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/PgxlPlugin.tsx
@@ -50,10 +50,10 @@ export function PgxlPlugin() {
         title="PowerGeniusXL"
         icon={<Zap className="w-5 h-5" />}
       >
-        <div className="flex flex-col items-center justify-center h-full p-8 text-gray-500">
+        <div className="flex flex-col items-center justify-center h-full p-8 text-dark-300">
           <WifiOff className="w-12 h-12 mb-4 opacity-50" />
-          <p className="text-center">No PGXL amplifiers found</p>
-          <p className="text-sm text-gray-600 mt-2 text-center">
+          <p className="text-center font-ui">No PGXL amplifiers found</p>
+          <p className="text-sm text-dark-300 mt-2 text-center font-ui">
             Waiting for PGXL discovery on port 9008
           </p>
         </div>
@@ -111,12 +111,12 @@ export function PgxlPlugin() {
       actions={
         <div className="flex items-center gap-2">
           {device.isConnected ? (
-            <span className="flex items-center gap-1.5 text-xs text-accent-success">
+            <span className="flex items-center gap-1.5 text-xs text-accent-success font-ui">
               <Wifi className="w-3.5 h-3.5" />
               Connected
             </span>
           ) : (
-            <span className="flex items-center gap-1.5 text-xs text-gray-500">
+            <span className="flex items-center gap-1.5 text-xs text-dark-300 font-ui">
               <WifiOff className="w-3.5 h-3.5" />
               Disconnected
             </span>
@@ -148,21 +148,21 @@ export function PgxlPlugin() {
 
           {/* Voltage/Temp Readings */}
           <div className="text-right text-sm space-y-0.5 min-w-[100px]">
-            <div className="text-gray-400">
-              <span className="text-gray-200">{tempA.toFixed(1)}</span>
-              <span className="text-gray-500"> / </span>
-              <span className="text-gray-200">{tempB.toFixed(1)}</span>
-              <span className="text-gray-500"> °C</span>
+            <div className="text-dark-300">
+              <span className="text-dark-200 font-display">{tempA.toFixed(1)}</span>
+              <span className="text-dark-300 font-ui"> / </span>
+              <span className="text-dark-200 font-display">{tempB.toFixed(1)}</span>
+              <span className="text-dark-300 font-ui"> °C</span>
             </div>
-            <div className="text-gray-400">
-              <span className="text-gray-500">Vdd </span>
-              <span className="text-gray-200">{vdd.toFixed(1)}</span>
-              <span className="text-gray-500"> V</span>
+            <div className="text-dark-300">
+              <span className="text-dark-300 font-ui">Vdd </span>
+              <span className="text-dark-200 font-display">{vdd.toFixed(1)}</span>
+              <span className="text-dark-300 font-ui"> V</span>
             </div>
-            <div className="text-gray-400">
-              <span className="text-gray-500">Vac </span>
-              <span className="text-gray-200">{vac}</span>
-              <span className="text-gray-500"> V</span>
+            <div className="text-dark-300">
+              <span className="text-dark-300 font-ui">Vac </span>
+              <span className="text-dark-200 font-display">{vac}</span>
+              <span className="text-dark-300 font-ui"> V</span>
             </div>
           </div>
         </div>
@@ -171,7 +171,7 @@ export function PgxlPlugin() {
         <div className="flex gap-2 px-3 pb-3">
           <button
             onClick={() => setShowSettings(true)}
-            className="px-4 py-2 text-sm font-medium bg-dark-700 text-gray-300 rounded-lg hover:bg-dark-600 transition-all border border-glass-100 flex items-center gap-2"
+            className="px-4 py-2 text-sm font-medium font-ui bg-dark-700 text-dark-200 rounded-lg hover:bg-dark-600 transition-all border border-glass-100 flex items-center gap-2"
           >
             <Settings className="w-4 h-4" />
             Settings
@@ -185,10 +185,10 @@ export function PgxlPlugin() {
                 setPgxlOperate(device.serial);
               }
             }}
-            className={`px-6 py-2 text-sm font-bold rounded-lg transition-all ${
+            className={`px-6 py-2 text-sm font-bold font-ui rounded-lg transition-all ${
               device.isOperating
-                ? 'bg-green-600 text-white hover:bg-green-700'
-                : 'bg-blue-600 text-white hover:bg-blue-700'
+                ? 'bg-accent-success/80 text-dark-900 hover:bg-accent-success'
+                : 'bg-accent-secondary/80 text-dark-900 hover:bg-accent-secondary'
             }`}
           >
             {device.isOperating ? 'Standby' : 'Operate'}
@@ -235,7 +235,7 @@ export function PgxlPlugin() {
 function StandbyDisplay() {
   return (
     <div className="flex items-center justify-center h-full min-h-[120px]">
-      <span className="text-4xl font-bold text-yellow-400 italic tracking-wider">
+      <span className="text-4xl font-bold font-display text-accent-primary italic tracking-wider">
         STANDBY
       </span>
     </div>
@@ -256,9 +256,9 @@ function OperatingDisplay({ forwardPower, swr, paCurrent }: OperatingDisplayProp
         label="Fwd Pwr"
         value={forwardPower}
         segments={[
-          { start: 0, end: 500, color: 'bg-green-500' },
-          { start: 500, end: 1500, color: 'bg-yellow-500' },
-          { start: 1500, end: 2000, color: 'bg-red-500' },
+          { start: 0, end: 500, color: 'bg-accent-success' },
+          { start: 500, end: 1500, color: 'bg-accent-primary' },
+          { start: 1500, end: 2000, color: 'bg-accent-danger' },
         ]}
         markers={[
           { value: 0, label: '0' },
@@ -274,9 +274,9 @@ function OperatingDisplay({ forwardPower, swr, paCurrent }: OperatingDisplayProp
         label="SWR"
         value={swr}
         segments={[
-          { start: 1, end: 1.5, color: 'bg-green-500' },
-          { start: 1.5, end: 2.5, color: 'bg-yellow-500' },
-          { start: 2.5, end: 3, color: 'bg-red-500' },
+          { start: 1, end: 1.5, color: 'bg-accent-success' },
+          { start: 1.5, end: 2.5, color: 'bg-accent-primary' },
+          { start: 2.5, end: 3, color: 'bg-accent-danger' },
         ]}
         markers={[
           { value: 1, label: '1' },
@@ -293,9 +293,9 @@ function OperatingDisplay({ forwardPower, swr, paCurrent }: OperatingDisplayProp
         label="Id"
         value={paCurrent}
         segments={[
-          { start: 0, end: 40, color: 'bg-green-500' },
-          { start: 40, end: 60, color: 'bg-yellow-500' },
-          { start: 60, end: 70, color: 'bg-red-500' },
+          { start: 0, end: 40, color: 'bg-accent-success' },
+          { start: 40, end: 60, color: 'bg-accent-primary' },
+          { start: 60, end: 70, color: 'bg-accent-danger' },
         ]}
         markers={[
           { value: 10, label: '10' },
@@ -349,12 +349,12 @@ function SegmentedMeter({
     <div className="relative">
       {/* Label and Markers Row */}
       <div className="flex items-center justify-between mb-1">
-        <span className="text-xs text-gray-400 w-16">{label}</span>
+        <span className="text-xs text-dark-300 font-ui w-16">{label}</span>
         <div className="flex-1 relative h-4">
           {markers.map((marker) => (
             <span
               key={marker.value}
-              className="absolute text-[10px] text-gray-500 transform -translate-x-1/2"
+              className="absolute text-[10px] text-dark-300 font-mono transform -translate-x-1/2"
               style={{ left: `${((marker.value - min) / range) * 100}%` }}
             >
               {marker.label}
@@ -362,7 +362,7 @@ function SegmentedMeter({
           ))}
         </div>
         {valueDisplay && (
-          <span className="text-xs text-blue-400 font-mono min-w-[50px] text-right">
+          <span className="text-xs text-accent-secondary font-display min-w-[50px] text-right">
             {valueDisplay}
           </span>
         )}
@@ -414,29 +414,29 @@ function SliceStatusRow({ label, config }: SliceStatusRowProps) {
     // Handle bias modes from PGXL (AB, AAB, A, B, or N/A)
     const modeUpper = mode.toUpperCase();
     if (modeUpper === 'AAB') {
-      return 'bg-green-600 text-white';
+      return 'bg-accent-success/80 text-dark-900';
     } else if (modeUpper === 'AB') {
-      return 'bg-blue-600 text-white';
+      return 'bg-accent-secondary/80 text-dark-900';
     } else if (modeUpper === 'A') {
-      return 'bg-green-600/70 text-white';
+      return 'bg-accent-success/50 text-dark-200';
     } else if (modeUpper === 'B') {
-      return 'bg-blue-600/70 text-white';
+      return 'bg-accent-secondary/50 text-dark-200';
     } else {
-      return 'bg-gray-600 text-white';
+      return 'bg-dark-600 text-dark-200';
     }
   };
 
   return (
     <div className="flex items-center gap-2 text-sm">
       {/* Slice Label */}
-      <span className="text-gray-400 font-medium w-4">{label}</span>
+      <span className="text-dark-300 font-ui font-medium w-4">{label}</span>
 
       {/* PTT Indicator */}
       <span
-        className={`px-2 py-0.5 rounded text-xs font-medium ${
+        className={`px-2 py-0.5 rounded text-xs font-medium font-ui ${
           config.pttActive
-            ? 'bg-red-600 text-white'
-            : 'bg-dark-700 text-gray-500'
+            ? 'bg-accent-danger text-dark-900'
+            : 'bg-dark-700 text-dark-300'
         }`}
       >
         PTT
@@ -446,8 +446,8 @@ function SliceStatusRow({ label, config }: SliceStatusRowProps) {
       <span
         className={`px-2 py-0.5 rounded text-xs font-mono min-w-[32px] text-center ${
           config.band !== 'N/A'
-            ? 'bg-blue-600 text-white'
-            : 'bg-dark-700 text-gray-500'
+            ? 'bg-accent-secondary/80 text-dark-900'
+            : 'bg-dark-700 text-dark-300'
         }`}
       >
         {config.band}
@@ -455,7 +455,7 @@ function SliceStatusRow({ label, config }: SliceStatusRowProps) {
 
       {/* Mode */}
       <span
-        className={`px-2 py-0.5 rounded text-xs font-medium min-w-[36px] text-center ${getModeColor(
+        className={`px-2 py-0.5 rounded text-xs font-medium font-ui min-w-[36px] text-center ${getModeColor(
           config.mode
         )}`}
       >
@@ -463,7 +463,7 @@ function SliceStatusRow({ label, config }: SliceStatusRowProps) {
       </span>
 
       {/* Radio Name */}
-      <span className="text-gray-300 flex-1 truncate">{config.radioName}</span>
+      <span className="text-dark-200 font-ui flex-1 truncate">{config.radioName}</span>
     </div>
   );
 }
@@ -475,14 +475,14 @@ interface StatusBadgeProps {
 
 function StatusBadge({ label, variant }: StatusBadgeProps) {
   const colors = {
-    danger: 'bg-red-500/20 text-red-400 border-red-500/30',
-    warning: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
-    success: 'bg-green-500/20 text-green-400 border-green-500/30',
+    danger: 'bg-accent-danger/20 text-accent-danger border-accent-danger/30',
+    warning: 'bg-accent-primary/20 text-accent-primary border-accent-primary/30',
+    success: 'bg-accent-success/20 text-accent-success border-accent-success/30',
   };
 
   return (
     <span
-      className={`px-2 py-0.5 text-xs font-medium rounded border ${colors[variant]} animate-pulse`}
+      className={`px-2 py-0.5 text-xs font-medium font-ui rounded border ${colors[variant]} animate-pulse`}
     >
       {label}
     </span>
@@ -521,10 +521,10 @@ function SettingsModal({ device, onClose, linkedRadioIdA, linkedRadioIdB, onDisa
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-dark-800 rounded-xl border border-glass-100 shadow-2xl w-full max-w-md mx-4">
         <div className="flex items-center justify-between px-4 py-3 border-b border-glass-100">
-          <h3 className="text-lg font-semibold text-gray-200">PGXL Settings</h3>
+          <h3 className="text-lg font-semibold font-ui text-dark-200">PGXL Settings</h3>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-200 transition-colors"
+            className="text-dark-300 hover:text-dark-200 transition-colors"
           >
             ✕
           </button>
@@ -533,48 +533,48 @@ function SettingsModal({ device, onClose, linkedRadioIdA, linkedRadioIdB, onDisa
         <div className="p-4 space-y-4">
           {/* Device Info */}
           <div className="bg-dark-700/50 rounded-lg p-3 border border-glass-100">
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-2">
+            <div className="text-xs text-dark-300 font-ui uppercase tracking-wider mb-2">
               Device Info
             </div>
             <div className="space-y-1 text-sm">
               <div className="flex justify-between">
-                <span className="text-gray-400">Serial:</span>
-                <span className="text-gray-200 font-mono">{device.serial}</span>
+                <span className="text-dark-300 font-ui">Serial:</span>
+                <span className="text-dark-200 font-mono">{device.serial}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-400">IP Address:</span>
-                <span className="text-gray-200 font-mono">{device.ipAddress}</span>
+                <span className="text-dark-300 font-ui">IP Address:</span>
+                <span className="text-dark-200 font-mono">{device.ipAddress}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-400">Band Source:</span>
-                <span className="text-gray-200">{device.setup.bandSource}</span>
+                <span className="text-dark-300 font-ui">Band Source:</span>
+                <span className="text-dark-200 font-ui">{device.setup.bandSource}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-400">Antenna:</span>
-                <span className="text-gray-200">ANT{device.setup.selectedAntenna}</span>
+                <span className="text-dark-300 font-ui">Antenna:</span>
+                <span className="text-dark-200 font-ui">ANT{device.setup.selectedAntenna}</span>
               </div>
             </div>
           </div>
 
           {/* FlexRadio Pairing */}
           <div className="bg-dark-700/50 rounded-lg p-3 border border-glass-100">
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-2">
+            <div className="text-xs text-dark-300 font-ui uppercase tracking-wider mb-2">
               FlexRadio Pairing
             </div>
-            <p className="text-xs text-gray-500 mb-3">
+            <p className="text-xs text-dark-300 font-ui mb-3">
               If the PGXL is paired with a FlexRadio, it will only accept PTT/band data from that radio.
               Disable pairing to use with TCI or other radios.
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => onDisableFlexPairing(device.serial, 'A')}
-                className="flex-1 px-3 py-1.5 text-sm font-medium bg-amber-600/20 text-amber-400 rounded-lg hover:bg-amber-600/30 transition-all border border-amber-600/30"
+                className="flex-1 px-3 py-1.5 text-sm font-medium font-ui bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-all border border-accent-primary/30"
               >
                 Unpair Side A
               </button>
               <button
                 onClick={() => onDisableFlexPairing(device.serial, 'B')}
-                className="flex-1 px-3 py-1.5 text-sm font-medium bg-amber-600/20 text-amber-400 rounded-lg hover:bg-amber-600/30 transition-all border border-amber-600/30"
+                className="flex-1 px-3 py-1.5 text-sm font-medium font-ui bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-all border border-accent-primary/30"
               >
                 Unpair Side B
               </button>
@@ -583,21 +583,21 @@ function SettingsModal({ device, onClose, linkedRadioIdA, linkedRadioIdB, onDisa
 
           {/* Radio Linking */}
           <div className="bg-dark-700/50 rounded-lg p-3 border border-glass-100">
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-2 flex items-center gap-2">
+            <div className="text-xs text-dark-300 font-ui uppercase tracking-wider mb-2 flex items-center gap-2">
               <Radio className="w-3.5 h-3.5" />
               Radio Linking
             </div>
-            <p className="text-xs text-gray-500 mb-3">
+            <p className="text-xs text-dark-300 font-ui mb-3">
               Link TCI/Hamlib radios to track band, mode, and PTT state
             </p>
             <div className="space-y-3">
               {/* Side A */}
               <div className="flex items-center gap-3">
-                <span className="text-gray-400 text-sm w-12">Side A:</span>
+                <span className="text-dark-300 font-ui text-sm w-12">Side A:</span>
                 <select
                   value={linkedRadioIdA || ''}
                   onChange={(e) => handleLinkChange('A', e.target.value)}
-                  className="flex-1 bg-dark-600 border border-glass-100 rounded-lg px-3 py-1.5 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-accent-primary"
+                  className="flex-1 bg-dark-600 border border-glass-100 rounded-lg px-3 py-1.5 text-sm text-dark-200 font-ui focus:outline-none focus:ring-2 focus:ring-accent-primary"
                 >
                   <option value="">Not linked</option>
                   {connectedRadios.map((radio) => (
@@ -610,11 +610,11 @@ function SettingsModal({ device, onClose, linkedRadioIdA, linkedRadioIdB, onDisa
 
               {/* Side B */}
               <div className="flex items-center gap-3">
-                <span className="text-gray-400 text-sm w-12">Side B:</span>
+                <span className="text-dark-300 font-ui text-sm w-12">Side B:</span>
                 <select
                   value={linkedRadioIdB || ''}
                   onChange={(e) => handleLinkChange('B', e.target.value)}
-                  className="flex-1 bg-dark-600 border border-glass-100 rounded-lg px-3 py-1.5 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-accent-primary"
+                  className="flex-1 bg-dark-600 border border-glass-100 rounded-lg px-3 py-1.5 text-sm text-dark-200 font-ui focus:outline-none focus:ring-2 focus:ring-accent-primary"
                 >
                   <option value="">Not linked</option>
                   {connectedRadios.map((radio) => (
@@ -627,7 +627,7 @@ function SettingsModal({ device, onClose, linkedRadioIdA, linkedRadioIdB, onDisa
             </div>
 
             {connectedRadios.length === 0 && (
-              <p className="text-xs text-amber-400 mt-2">
+              <p className="text-xs text-accent-primary font-ui mt-2">
                 No radios connected. Connect a TCI or rigctld radio first.
               </p>
             )}
@@ -637,7 +637,7 @@ function SettingsModal({ device, onClose, linkedRadioIdA, linkedRadioIdB, onDisa
         <div className="flex justify-end gap-2 px-4 py-3 border-t border-glass-100">
           <button
             onClick={onClose}
-            className="px-4 py-2 text-sm font-medium bg-dark-700 text-gray-300 rounded-lg hover:bg-dark-600 transition-all border border-glass-100"
+            className="px-4 py-2 text-sm font-medium font-ui bg-dark-700 text-dark-200 rounded-lg hover:bg-dark-600 transition-all border border-glass-100"
           >
             Close
           </button>

--- a/src/Log4YM.Web/src/plugins/QrzProfilePlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/QrzProfilePlugin.tsx
@@ -30,7 +30,7 @@ export function QrzProfilePlugin() {
           <div className="flex-1 flex items-center justify-center">
             <div className="text-center">
               <div className="w-16 h-16 mx-auto mb-4 rounded-full border-4 border-accent-primary/30 border-t-accent-primary animate-spin" />
-              <p className="text-gray-400 text-sm">Looking up callsign...</p>
+              <p className="text-dark-300 text-sm font-ui">Looking up callsign...</p>
             </div>
           </div>
         )}
@@ -39,9 +39,9 @@ export function QrzProfilePlugin() {
         {!isLookingUpCallsign && !focusedCallsignInfo && (
           <div className="flex-1 flex items-center justify-center">
             <div className="text-center">
-              <User className="w-16 h-16 text-gray-600 mx-auto mb-4" />
-              <p className="text-gray-400 text-lg font-medium mb-2">No Callsign Selected</p>
-              <p className="text-gray-500 text-sm">
+              <User className="w-16 h-16 text-dark-300 mx-auto mb-4" />
+              <p className="text-dark-300 text-lg font-medium font-ui mb-2">No Callsign Selected</p>
+              <p className="text-dark-300 text-sm font-ui">
                 Enter a callsign in the Log Entry to see profile information.
               </p>
             </div>
@@ -57,11 +57,11 @@ export function QrzProfilePlugin() {
                 <img
                   src={focusedCallsignInfo.imageUrl}
                   alt={focusedCallsignInfo.callsign}
-                  className="w-32 h-32 rounded-xl object-cover border-2 border-glass-200 shadow-lg"
+                  className="w-32 h-32 rounded-xl object-cover border-2 border-glass-100 shadow-lg"
                 />
               ) : (
-                <div className="w-32 h-32 rounded-xl bg-dark-700 border-2 border-glass-200 flex items-center justify-center">
-                  <User className="w-16 h-16 text-gray-600" />
+                <div className="w-32 h-32 rounded-xl bg-dark-700 border-2 border-glass-100 flex items-center justify-center">
+                  <User className="w-16 h-16 text-dark-300" />
                 </div>
               )}
             </div>
@@ -76,7 +76,7 @@ export function QrzProfilePlugin() {
                   {focusedCallsignInfo.callsign}
                 </h2>
               </div>
-              <p className="text-lg text-gray-200">
+              <p className="text-lg text-dark-200 font-ui">
                 {focusedCallsignInfo.name || 'No name on file'}
               </p>
             </div>
@@ -85,22 +85,22 @@ export function QrzProfilePlugin() {
             <div className="space-y-3">
               {/* Country */}
               {focusedCallsignInfo.country && (
-                <div className="flex items-center gap-3 text-gray-300">
-                  <Globe className="w-4 h-4 text-gray-500" />
+                <div className="flex items-center gap-3 text-dark-200 font-ui">
+                  <Globe className="w-4 h-4 text-dark-300" />
                   <span>{focusedCallsignInfo.country}</span>
                   {focusedCallsignInfo.state && (
-                    <span className="text-gray-500">({focusedCallsignInfo.state})</span>
+                    <span className="text-dark-300">({focusedCallsignInfo.state})</span>
                   )}
                 </div>
               )}
 
               {/* Grid square */}
               {focusedCallsignInfo.grid && (
-                <div className="flex items-center gap-3 text-gray-300">
-                  <MapPin className="w-4 h-4 text-gray-500" />
+                <div className="flex items-center gap-3 text-dark-200">
+                  <MapPin className="w-4 h-4 text-dark-300" />
                   <span className="font-mono">{focusedCallsignInfo.grid}</span>
                   {focusedCallsignInfo.latitude != null && focusedCallsignInfo.longitude != null && (
-                    <span className="text-gray-500 text-sm">
+                    <span className="text-dark-300 text-sm font-mono">
                       ({focusedCallsignInfo.latitude.toFixed(2)}°, {focusedCallsignInfo.longitude.toFixed(2)}°)
                     </span>
                   )}
@@ -109,19 +109,19 @@ export function QrzProfilePlugin() {
 
               {/* Bearing and distance */}
               {shortPath != null && (
-                <div className="flex items-center gap-3 text-gray-300">
-                  <Navigation className="w-4 h-4 text-gray-500" />
+                <div className="flex items-center gap-3 text-dark-200">
+                  <Navigation className="w-4 h-4 text-dark-300" />
                   <div className="flex items-center gap-4">
                     <span>
-                      <span className="text-accent-warning font-mono">{shortPath.toFixed(0)}°</span>
-                      <span className="text-gray-500 text-xs ml-1">SP</span>
+                      <span className="text-accent-primary font-mono">{shortPath.toFixed(0)}°</span>
+                      <span className="text-dark-300 text-xs ml-1 font-ui">SP</span>
                     </span>
                     <span>
-                      <span className="text-accent-warning font-mono">{longPath?.toFixed(0)}°</span>
-                      <span className="text-gray-500 text-xs ml-1">LP</span>
+                      <span className="text-accent-primary font-mono">{longPath?.toFixed(0)}°</span>
+                      <span className="text-dark-300 text-xs ml-1 font-ui">LP</span>
                     </span>
                     {focusedCallsignInfo.distance != null && (
-                      <span className="text-accent-info">
+                      <span className="text-accent-secondary font-mono">
                         {Math.round(focusedCallsignInfo.distance).toLocaleString()} km
                       </span>
                     )}
@@ -131,15 +131,15 @@ export function QrzProfilePlugin() {
 
               {/* DXCC / CQ / ITU zones */}
               {(focusedCallsignInfo.dxcc || focusedCallsignInfo.cqZone || focusedCallsignInfo.ituZone) && (
-                <div className="flex items-center gap-4 text-sm text-gray-400 pt-2 border-t border-glass-100">
+                <div className="flex items-center gap-4 text-sm text-dark-300 font-ui pt-2 border-t border-glass-100">
                   {focusedCallsignInfo.dxcc && (
-                    <span>DXCC: <span className="text-gray-300">{focusedCallsignInfo.dxcc}</span></span>
+                    <span>DXCC: <span className="text-dark-200 font-mono">{focusedCallsignInfo.dxcc}</span></span>
                   )}
                   {focusedCallsignInfo.cqZone && (
-                    <span>CQ: <span className="text-gray-300">{focusedCallsignInfo.cqZone}</span></span>
+                    <span>CQ: <span className="text-dark-200 font-mono">{focusedCallsignInfo.cqZone}</span></span>
                   )}
                   {focusedCallsignInfo.ituZone && (
-                    <span>ITU: <span className="text-gray-300">{focusedCallsignInfo.ituZone}</span></span>
+                    <span>ITU: <span className="text-dark-200 font-mono">{focusedCallsignInfo.ituZone}</span></span>
                   )}
                 </div>
               )}
@@ -147,7 +147,7 @@ export function QrzProfilePlugin() {
               {/* View on QRZ button */}
               <button
                 onClick={handleOpenQrz}
-                className="mt-4 w-full glass-button py-2 flex items-center justify-center gap-2 text-accent-primary hover:bg-accent-primary/10 transition-colors"
+                className="mt-4 w-full glass-button py-2 flex items-center justify-center gap-2 text-accent-primary hover:bg-dark-600 transition-colors font-ui"
               >
                 <ExternalLink className="w-4 h-4" />
                 <span className="text-sm font-medium">View Full QRZ Profile</span>

--- a/src/Log4YM.Web/src/plugins/RigPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/RigPlugin.tsx
@@ -360,14 +360,14 @@ export function RigPlugin() {
     switch (state) {
       case "Connected":
       case "Monitoring":
-        return "text-green-400";
+        return "text-accent-success";
       case "Connecting":
       case "Discovering":
-        return "text-yellow-400";
+        return "text-accent-primary";
       case "Error":
-        return "text-red-400";
+        return "text-accent-danger";
       default:
-        return "text-gray-500";
+        return "text-dark-300";
     }
   };
 
@@ -411,13 +411,13 @@ export function RigPlugin() {
               className={`p-1.5 rounded transition-all ${
                 autoReconnect
                   ? "bg-accent-primary/20 text-accent-primary"
-                  : "bg-dark-700 text-gray-500 hover:text-gray-400"
+                  : "bg-dark-700 text-dark-300 hover:text-dark-200"
               }`}
             >
               <RefreshCw className={`w-3.5 h-3.5 ${autoReconnect ? "" : "opacity-50"}`} />
             </button>
             <span
-              className={`flex items-center gap-1.5 text-xs ${getConnectionStateColor(
+              className={`flex items-center gap-1.5 text-xs font-mono ${getConnectionStateColor(
                 effectiveConnectionState
               )}`}
             >
@@ -430,8 +430,8 @@ export function RigPlugin() {
         <div className="p-4 space-y-4">
           {/* Radio Info */}
           <div className="flex items-center justify-between">
-            <div className="text-sm text-gray-400">
-              <span className="font-medium text-gray-200">
+            <div className="text-sm text-dark-300 font-ui">
+              <span className="font-medium text-dark-200">
                 {radioInfo.model}
               </span>
               <span className="mx-2">|</span>
@@ -440,14 +440,14 @@ export function RigPlugin() {
               </span>
             </div>
             {(isConnecting || isLocallyConnecting) && !isConnected ? (
-              <div className="px-3 py-1.5 text-xs font-medium flex items-center gap-1.5 bg-yellow-500/20 text-yellow-400 rounded-lg">
+              <div className="px-3 py-1.5 text-xs font-medium font-ui flex items-center gap-1.5 bg-accent-primary/20 text-accent-primary rounded-lg">
                 <Wifi className="w-3.5 h-3.5 animate-pulse" />
                 Connecting...
               </div>
             ) : (
               <button
                 onClick={handleDisconnect}
-                className="px-3 py-1.5 text-xs font-medium flex items-center gap-1.5 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-all"
+                className="px-3 py-1.5 text-xs font-medium font-ui flex items-center gap-1.5 bg-accent-danger/20 text-accent-danger rounded-lg hover:bg-accent-danger/30 transition-all"
               >
                 <PowerOff className="w-3.5 h-3.5" />
                 Disconnect
@@ -457,17 +457,17 @@ export function RigPlugin() {
 
           {/* Frequency Display */}
           <div className="bg-dark-700/50 rounded-lg p-4 border border-glass-100">
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">
+            <div className="text-xs text-dark-300 uppercase tracking-wider mb-1 font-ui">
               Frequency
             </div>
-            <div className="text-3xl font-bold text-accent-primary font-mono">
+            <div className="text-3xl font-bold text-accent-primary font-display">
               {selectedRadioState
                 ? formatFrequency(selectedRadioState.frequencyHz)
                 : (isConnecting || isLocallyConnecting) && !isConnected
-                ? <span className="text-gray-500 text-lg animate-pulse">Waiting for data...</span>
+                ? <span className="text-dark-300 text-lg animate-pulse font-ui">Waiting for data...</span>
                 : "---"}
               {selectedRadioState && (
-                <span className="text-lg font-normal text-gray-500 ml-2">
+                <span className="text-lg font-normal text-dark-300 ml-2 font-ui">
                   MHz
                 </span>
               )}
@@ -477,18 +477,18 @@ export function RigPlugin() {
           {/* Mode and Band */}
           <div className="grid grid-cols-2 gap-3">
             <div className="bg-dark-700/50 rounded-lg p-3 border border-glass-100">
-              <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">
+              <div className="text-xs text-dark-300 uppercase tracking-wider mb-1 font-ui">
                 Mode
               </div>
-              <div className="text-xl font-bold text-accent-secondary">
+              <div className="text-xl font-bold text-accent-secondary font-mono">
                 {selectedRadioState?.mode || "---"}
               </div>
             </div>
             <div className="bg-dark-700/50 rounded-lg p-3 border border-glass-100">
-              <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">
+              <div className="text-xs text-dark-300 uppercase tracking-wider mb-1 font-ui">
                 Band
               </div>
-              <div className="text-xl font-bold text-accent-primary">
+              <div className="text-xl font-bold text-accent-primary font-mono">
                 {selectedRadioState?.band || "---"}
               </div>
             </div>
@@ -500,9 +500,9 @@ export function RigPlugin() {
               isTransmitting={selectedRadioState?.isTransmitting ?? false}
             />
             {selectedRadioState?.sliceOrInstance && (
-              <span className="text-sm text-gray-400">
+              <span className="text-sm text-dark-300 font-ui">
                 Slice:{" "}
-                <span className="text-gray-200">
+                <span className="text-dark-200 font-mono">
                   {selectedRadioState.sliceOrInstance}
                 </span>
               </span>
@@ -523,7 +523,7 @@ export function RigPlugin() {
       <div className="p-4 space-y-4">
         {/* Radio Type Selection */}
         <div>
-          <div className="text-xs text-gray-500 uppercase tracking-wider mb-2">
+          <div className="text-xs text-dark-300 uppercase tracking-wider mb-2 font-ui">
             Radio Type
           </div>
           <div className="grid grid-cols-2 gap-2">
@@ -532,10 +532,10 @@ export function RigPlugin() {
                 setShowTciForm(!showTciForm);
                 setShowHamlibForm(false);
               }}
-              className={`px-4 py-3 rounded-lg text-sm font-medium transition-all border ${
+              className={`px-4 py-3 rounded-lg text-sm font-medium font-ui transition-all border ${
                 showTciForm
-                  ? "bg-purple-500/20 text-purple-400 border-purple-500/30"
-                  : "bg-dark-700 text-gray-300 hover:bg-dark-600 border-glass-100"
+                  ? "bg-accent-secondary/20 text-accent-secondary border-accent-secondary/30"
+                  : "bg-dark-700 text-dark-200 hover:bg-dark-600 border-glass-100"
               }`}
             >
               <div className="flex flex-col items-center gap-1">
@@ -548,10 +548,10 @@ export function RigPlugin() {
                 setShowHamlibForm(!showHamlibForm);
                 setShowTciForm(false);
               }}
-              className={`px-4 py-3 rounded-lg text-sm font-medium transition-all border ${
+              className={`px-4 py-3 rounded-lg text-sm font-medium font-ui transition-all border ${
                 showHamlibForm
-                  ? "bg-orange-500/20 text-orange-400 border-orange-500/30"
-                  : "bg-dark-700 text-gray-300 hover:bg-dark-600 border-glass-100"
+                  ? "bg-accent-primary/20 text-accent-primary border-accent-primary/30"
+                  : "bg-dark-700 text-dark-200 hover:bg-dark-600 border-glass-100"
               }`}
             >
               <div className="flex flex-col items-center gap-1">
@@ -564,14 +564,14 @@ export function RigPlugin() {
 
         {/* Hamlib Configuration Form */}
         {showHamlibForm && (
-          <div className="bg-dark-700/50 rounded-lg p-4 border border-orange-500/30 space-y-4">
-            <div className="text-xs text-orange-400 uppercase tracking-wider">
+          <div className="bg-dark-700/50 rounded-lg p-4 border border-accent-primary/30 space-y-4">
+            <div className="text-xs text-accent-primary uppercase tracking-wider font-ui">
               Hamlib Rig Configuration
             </div>
 
             {/* Rig Model Selector */}
             <div className="relative">
-              <label className="block text-xs text-gray-500 mb-1">Rig Model</label>
+              <label className="block text-xs text-dark-300 mb-1 font-ui">Rig Model</label>
               <input
                 type="text"
                 value={rigSearch}
@@ -581,7 +581,7 @@ export function RigPlugin() {
                 }}
                 onFocus={() => setShowRigDropdown(true)}
                 placeholder="Search for rig model..."
-                className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
               />
               {showRigDropdown && filteredRigs.length > 0 && (
                 <div className="absolute z-50 w-full mt-1 max-h-48 overflow-y-auto bg-dark-800 border border-glass-100 rounded-lg shadow-lg">
@@ -589,10 +589,10 @@ export function RigPlugin() {
                     <button
                       key={rig.modelId}
                       onClick={() => handleRigSelect(rig)}
-                      className="w-full px-3 py-2 text-left text-sm text-gray-200 hover:bg-dark-700 transition-colors"
+                      className="w-full px-3 py-2 text-left text-sm text-dark-200 hover:bg-dark-700 transition-colors"
                     >
-                      <div className="font-medium">{rig.displayName}</div>
-                      <div className="text-xs text-gray-500">{rig.manufacturer} - {rig.model}</div>
+                      <div className="font-medium font-ui">{rig.displayName}</div>
+                      <div className="text-xs text-dark-300 font-mono">{rig.manufacturer} - {rig.model}</div>
                     </button>
                   ))}
                 </div>
@@ -601,16 +601,16 @@ export function RigPlugin() {
 
             {/* Connection Type Toggle - only show options that are supported */}
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Connection Type</label>
+              <label className="block text-xs text-dark-300 mb-1 font-ui">Connection Type</label>
               <div className="flex gap-2">
                 {/* Only show Serial option if supported */}
                 {(!hamlibCaps || hamlibCaps.supportsSerial) && (
                   <button
                     onClick={() => updateHamlibConfig({ connectionType: "Serial" })}
-                    className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                    className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium font-ui transition-all ${
                       hamlibConfig.connectionType === "Serial"
-                        ? "bg-orange-500/20 text-orange-400 border border-orange-500/30"
-                        : "bg-dark-800 text-gray-400 border border-glass-100 hover:bg-dark-700"
+                        ? "bg-accent-primary/20 text-accent-primary border border-accent-primary/30"
+                        : "bg-dark-800 text-dark-300 border border-glass-100 hover:bg-dark-700"
                     }`}
                   >
                     Serial
@@ -620,10 +620,10 @@ export function RigPlugin() {
                 {(!hamlibCaps || hamlibCaps.supportsNetwork) && (
                   <button
                     onClick={() => updateHamlibConfig({ connectionType: "Network", hostname: hamlibConfig.hostname || "localhost" })}
-                    className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                    className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium font-ui transition-all ${
                       hamlibConfig.connectionType === "Network"
-                        ? "bg-orange-500/20 text-orange-400 border border-orange-500/30"
-                        : "bg-dark-800 text-gray-400 border border-glass-100 hover:bg-dark-700"
+                        ? "bg-accent-primary/20 text-accent-primary border border-accent-primary/30"
+                        : "bg-dark-800 text-dark-300 border border-glass-100 hover:bg-dark-700"
                     }`}
                   >
                     Network
@@ -637,11 +637,11 @@ export function RigPlugin() {
               <div className="space-y-3">
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">Serial Port</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">Serial Port</label>
                     <select
                       value={hamlibConfig.serialPort || ""}
                       onChange={(e) => updateHamlibConfig({ serialPort: e.target.value })}
-                      className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       <option value="">Select port...</option>
                       {serialPorts.map((port) => (
@@ -650,11 +650,11 @@ export function RigPlugin() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">Baud Rate</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">Baud Rate</label>
                     <select
                       value={hamlibConfig.baudRate}
                       onChange={(e) => updateHamlibConfig({ baudRate: parseInt(e.target.value) })}
-                      className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       {HAMLIB_BAUD_RATES.map((rate) => (
                         <option key={rate} value={rate}>{rate}</option>
@@ -665,11 +665,11 @@ export function RigPlugin() {
 
                 <div className="grid grid-cols-4 gap-2">
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">Data Bits</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">Data Bits</label>
                     <select
                       value={hamlibConfig.dataBits}
                       onChange={(e) => updateHamlibConfig({ dataBits: parseInt(e.target.value) as HamlibDataBits })}
-                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       <option value={5}>5</option>
                       <option value={6}>6</option>
@@ -678,22 +678,22 @@ export function RigPlugin() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">Stop Bits</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">Stop Bits</label>
                     <select
                       value={hamlibConfig.stopBits}
                       onChange={(e) => updateHamlibConfig({ stopBits: parseInt(e.target.value) as HamlibStopBits })}
-                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       <option value={1}>1</option>
                       <option value={2}>2</option>
                     </select>
                   </div>
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">Flow</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">Flow</label>
                     <select
                       value={hamlibConfig.flowControl}
                       onChange={(e) => updateHamlibConfig({ flowControl: e.target.value as HamlibFlowControl })}
-                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       <option value="None">None</option>
                       <option value="Hardware">HW</option>
@@ -701,11 +701,11 @@ export function RigPlugin() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">Parity</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">Parity</label>
                     <select
                       value={hamlibConfig.parity}
                       onChange={(e) => updateHamlibConfig({ parity: e.target.value as HamlibParity })}
-                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-2 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       <option value="None">None</option>
                       <option value="Even">Even</option>
@@ -719,11 +719,11 @@ export function RigPlugin() {
                 {/* PTT Configuration */}
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-xs text-gray-500 mb-1">PTT Type</label>
+                    <label className="block text-xs text-dark-300 mb-1 font-ui">PTT Type</label>
                     <select
                       value={hamlibConfig.pttType}
                       onChange={(e) => updateHamlibConfig({ pttType: e.target.value as HamlibPttType })}
-                      className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                      className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                     >
                       <option value="None">None</option>
                       <option value="Rig">CAT (RIG)</option>
@@ -733,11 +733,11 @@ export function RigPlugin() {
                   </div>
                   {(hamlibConfig.pttType === "Dtr" || hamlibConfig.pttType === "Rts") && (
                     <div>
-                      <label className="block text-xs text-gray-500 mb-1">PTT Port</label>
+                      <label className="block text-xs text-dark-300 mb-1 font-ui">PTT Port</label>
                       <select
                         value={hamlibConfig.pttPort || ""}
                         onChange={(e) => updateHamlibConfig({ pttPort: e.target.value })}
-                        className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                        className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                       >
                         <option value="">Same as data</option>
                         {serialPorts.map((port) => (
@@ -754,23 +754,23 @@ export function RigPlugin() {
             {hamlibConfig.connectionType === "Network" && (
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">Hostname</label>
+                  <label className="block text-xs text-dark-300 mb-1 font-ui">Hostname</label>
                   <input
                     type="text"
                     value={hamlibConfig.hostname || ""}
                     onChange={(e) => updateHamlibConfig({ hostname: e.target.value })}
                     placeholder="localhost"
-                    className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                    className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                   />
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">Port</label>
+                  <label className="block text-xs text-dark-300 mb-1 font-ui">Port</label>
                   <input
                     type="number"
                     value={hamlibConfig.networkPort}
                     onChange={(e) => updateHamlibConfig({ networkPort: parseInt(e.target.value) || 4532 })}
                     placeholder="4532"
-                    className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                    className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                   />
                 </div>
               </div>
@@ -779,7 +779,7 @@ export function RigPlugin() {
             {/* Advanced Options Toggle */}
             <button
               onClick={() => setShowAdvanced(!showAdvanced)}
-              className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-400 transition-colors"
+              className="flex items-center gap-1 text-xs text-dark-300 hover:text-dark-200 transition-colors font-ui"
             >
               {showAdvanced ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
               Advanced Options
@@ -788,7 +788,7 @@ export function RigPlugin() {
             {/* Advanced Options */}
             {showAdvanced && (
               <div className="space-y-3 pt-2 border-t border-glass-100">
-                <div className="text-xs text-gray-500 mb-2">Feature Toggles</div>
+                <div className="text-xs text-dark-300 mb-2 font-ui">Feature Toggles</div>
                 <div className="grid grid-cols-2 gap-2">
                   <FeatureToggle
                     label="Get Frequency"
@@ -841,14 +841,14 @@ export function RigPlugin() {
                 </div>
 
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">Poll Interval (ms)</label>
+                  <label className="block text-xs text-dark-300 mb-1 font-ui">Poll Interval (ms)</label>
                   <input
                     type="number"
                     value={hamlibConfig.pollIntervalMs}
                     onChange={(e) => updateHamlibConfig({ pollIntervalMs: parseInt(e.target.value) || 250 })}
                     min={50}
                     max={5000}
-                    className="w-32 px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-500/50"
+                    className="w-32 px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-primary/50"
                   />
                 </div>
               </div>
@@ -859,7 +859,7 @@ export function RigPlugin() {
               <button
                 onClick={handleConnectHamlib}
                 disabled={isConnectingHamlib || !hamlibConfig.modelId || (hamlibConfig.connectionType === "Serial" && !hamlibConfig.serialPort) || (hamlibConfig.connectionType === "Network" && !hamlibConfig.hostname)}
-                className="flex-1 px-4 py-2 text-sm font-medium flex items-center justify-center gap-2 bg-orange-500/20 text-orange-400 rounded-lg hover:bg-orange-500/30 transition-all disabled:opacity-50"
+                className="flex-1 px-4 py-2 text-sm font-medium font-ui flex items-center justify-center gap-2 bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-all disabled:opacity-50"
               >
                 {isConnectingHamlib ? (
                   <>
@@ -875,7 +875,7 @@ export function RigPlugin() {
               </button>
               <button
                 onClick={() => setShowHamlibForm(false)}
-                className="px-4 py-2 text-sm font-medium bg-dark-700 text-gray-400 rounded-lg hover:bg-dark-600 transition-all"
+                className="px-4 py-2 text-sm font-medium font-ui bg-dark-700 text-dark-300 rounded-lg hover:bg-dark-600 transition-all"
               >
                 Cancel
               </button>
@@ -885,43 +885,43 @@ export function RigPlugin() {
 
         {/* TCI Connection Form */}
         {showTciForm && (
-          <div className="bg-dark-700/50 rounded-lg p-4 border border-purple-500/30 space-y-3">
-            <div className="text-xs text-purple-400 uppercase tracking-wider mb-2">
+          <div className="bg-dark-700/50 rounded-lg p-4 border border-accent-secondary/30 space-y-3">
+            <div className="text-xs text-accent-secondary uppercase tracking-wider mb-2 font-ui">
               Connect to TCI Server
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Host</label>
+                <label className="block text-xs text-dark-300 mb-1 font-ui">Host</label>
                 <input
                   type="text"
                   value={tciSettings.host}
                   onChange={(e) => updateTciSettings({ host: e.target.value })}
                   placeholder="localhost"
-                  className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-purple-500/50"
+                  className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-secondary/50"
                 />
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Port</label>
+                <label className="block text-xs text-dark-300 mb-1 font-ui">Port</label>
                 <input
                   type="number"
                   value={tciSettings.port}
                   onChange={(e) => updateTciSettings({ port: parseInt(e.target.value) || 50001 })}
                   placeholder="50001"
-                  className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-purple-500/50"
+                  className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-secondary/50"
                 />
               </div>
             </div>
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Name (optional)</label>
+              <label className="block text-xs text-dark-300 mb-1 font-ui">Name (optional)</label>
               <input
                 type="text"
                 value={tciSettings.name}
                 onChange={(e) => updateTciSettings({ name: e.target.value })}
                 placeholder="My TCI Radio"
-                className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-purple-500/50"
+                className="w-full px-3 py-2 bg-dark-800 border border-glass-100 rounded-lg text-sm text-dark-200 font-mono focus:outline-none focus:border-accent-secondary/50"
               />
             </div>
-            <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+            <label className="flex items-center gap-2 text-sm text-dark-200 cursor-pointer font-ui">
               <input
                 type="checkbox"
                 checked={tciSettings.autoConnect}
@@ -929,7 +929,7 @@ export function RigPlugin() {
                   updateTciSettings({ autoConnect: e.target.checked });
                   saveSettings();
                 }}
-                className="w-4 h-4 rounded border-glass-100 bg-dark-800 text-purple-500 focus:ring-purple-500/50"
+                className="w-4 h-4 rounded border-glass-100 bg-dark-800 text-accent-secondary focus:ring-accent-secondary/50"
               />
               Auto-connect on startup
             </label>
@@ -937,7 +937,7 @@ export function RigPlugin() {
               <button
                 onClick={handleConnectTci}
                 disabled={isConnectingTci || !tciSettings.host}
-                className="flex-1 px-4 py-2 text-sm font-medium flex items-center justify-center gap-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-all disabled:opacity-50"
+                className="flex-1 px-4 py-2 text-sm font-medium font-ui flex items-center justify-center gap-2 bg-accent-secondary/20 text-accent-secondary rounded-lg hover:bg-accent-secondary/30 transition-all disabled:opacity-50"
               >
                 {isConnectingTci ? (
                   <>
@@ -953,7 +953,7 @@ export function RigPlugin() {
               </button>
               <button
                 onClick={() => setShowTciForm(false)}
-                className="px-4 py-2 text-sm font-medium bg-dark-700 text-gray-400 rounded-lg hover:bg-dark-600 transition-all"
+                className="px-4 py-2 text-sm font-medium font-ui bg-dark-700 text-dark-300 rounded-lg hover:bg-dark-600 transition-all"
               >
                 Cancel
               </button>
@@ -964,7 +964,7 @@ export function RigPlugin() {
         {/* Saved Rig - only show if we have a configured rig and not showing forms */}
         {radios.length > 0 && !showTciForm && !showHamlibForm ? (
           <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-2">
+            <div className="text-xs text-dark-300 uppercase tracking-wider mb-2 font-ui">
               Saved Rig
             </div>
             <div className="space-y-2">
@@ -981,18 +981,18 @@ export function RigPlugin() {
                       <div
                         className={`p-2 rounded-lg ${
                           radio.type === "Hamlib"
-                            ? "bg-orange-500/20"
-                            : "bg-purple-500/20"
+                            ? "bg-accent-primary/20"
+                            : "bg-accent-secondary/20"
                         }`}
                       >
                         {radio.type === "Hamlib" ? (
-                          <Settings className="w-4 h-4 text-orange-400" />
+                          <Settings className="w-4 h-4 text-accent-primary" />
                         ) : (
-                          <Radio className="w-4 h-4 text-purple-400" />
+                          <Radio className="w-4 h-4 text-accent-secondary" />
                         )}
                       </div>
                       <div>
-                        <div className="text-sm font-medium text-gray-200 flex items-center gap-1.5">
+                        <div className="text-sm font-medium text-dark-200 font-ui flex items-center gap-1.5">
                           {radio.nickname || radio.model}
                           {autoReconnect && autoConnectRigId === radio.id && (
                             <span title="Auto-connect enabled">
@@ -1000,7 +1000,7 @@ export function RigPlugin() {
                             </span>
                           )}
                         </div>
-                        <div className="text-xs text-gray-500 font-mono">
+                        <div className="text-xs text-dark-300 font-mono">
                           {radio.ipAddress}{radio.port ? `:${radio.port}` : ""}
                         </div>
                       </div>
@@ -1012,7 +1012,7 @@ export function RigPlugin() {
                         className={`p-1.5 rounded transition-all ${
                           autoReconnect && autoConnectRigId === radio.id
                             ? "bg-accent-primary/20 text-accent-primary"
-                            : "bg-dark-700 text-gray-500 hover:text-gray-400"
+                            : "bg-dark-700 text-dark-300 hover:text-dark-200"
                         }`}
                       >
                         <RefreshCw className={`w-3.5 h-3.5 ${autoReconnect && autoConnectRigId === radio.id ? "" : "opacity-50"}`} />
@@ -1020,7 +1020,7 @@ export function RigPlugin() {
                       <button
                         onClick={() => handleConnect(radio.id)}
                         disabled={isConnecting}
-                        className="px-3 py-1.5 text-xs font-medium flex items-center gap-1.5 bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-all disabled:opacity-50"
+                        className="px-3 py-1.5 text-xs font-medium font-ui flex items-center gap-1.5 bg-accent-primary/20 text-accent-primary rounded-lg hover:bg-accent-primary/30 transition-all disabled:opacity-50"
                       >
                         {isConnecting ? (
                           <>
@@ -1036,7 +1036,7 @@ export function RigPlugin() {
                       </button>
                       <button
                         onClick={() => handleRemoveRig(radio.id)}
-                        className="px-3 py-1.5 text-xs font-medium flex items-center gap-1.5 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-all"
+                        className="px-3 py-1.5 text-xs font-medium font-ui flex items-center gap-1.5 bg-accent-danger/20 text-accent-danger rounded-lg hover:bg-accent-danger/30 transition-all"
                         title="Remove saved rig"
                       >
                         <PowerOff className="w-3.5 h-3.5" />
@@ -1049,10 +1049,10 @@ export function RigPlugin() {
             </div>
           </div>
         ) : !showTciForm && !showHamlibForm ? (
-          <div className="flex flex-col items-center justify-center py-8 text-gray-500">
+          <div className="flex flex-col items-center justify-center py-8 text-dark-300">
             <WifiOff className="w-8 h-8 mb-3 opacity-50" />
-            <p className="text-sm text-center">No rig configured</p>
-            <p className="text-xs text-gray-600 mt-1 text-center">
+            <p className="text-sm text-center font-ui">No rig configured</p>
+            <p className="text-xs text-dark-400 mt-1 text-center font-ui">
               Select a radio type above to configure
             </p>
           </div>
@@ -1077,9 +1077,9 @@ function FeatureToggle({ label, checked, onChange, disabled }: FeatureToggleProp
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
         disabled={disabled}
-        className="w-4 h-4 rounded bg-dark-800 border-glass-100 text-orange-500 focus:ring-orange-500/50"
+        className="w-4 h-4 rounded bg-dark-800 border-glass-100 text-accent-primary focus:ring-accent-primary/50"
       />
-      <span className="text-gray-300">{label}</span>
+      <span className="text-dark-200 font-ui">{label}</span>
     </label>
   );
 }
@@ -1092,19 +1092,19 @@ function TxRxIndicator({ isTransmitting }: TxRxIndicatorProps) {
   return (
     <div className="flex rounded-lg overflow-hidden border border-glass-100">
       <div
-        className={`px-3 py-1.5 text-xs font-bold transition-all ${
+        className={`px-3 py-1.5 text-xs font-bold font-mono transition-all ${
           !isTransmitting
-            ? "bg-green-500/30 text-green-400 border-r border-green-500/30"
-            : "bg-dark-700 text-gray-600 border-r border-glass-100"
+            ? "bg-accent-success/30 text-accent-success border-r border-accent-success/30"
+            : "bg-dark-700 text-dark-600 border-r border-glass-100"
         }`}
       >
         RX
       </div>
       <div
-        className={`px-3 py-1.5 text-xs font-bold transition-all ${
+        className={`px-3 py-1.5 text-xs font-bold font-mono transition-all ${
           isTransmitting
-            ? "bg-red-500/30 text-red-400 animate-pulse"
-            : "bg-dark-700 text-gray-600"
+            ? "bg-accent-danger/30 text-accent-danger animate-pulse"
+            : "bg-dark-700 text-dark-600"
         }`}
       >
         TX

--- a/src/Log4YM.Web/src/plugins/RotatorPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/RotatorPlugin.tsx
@@ -160,9 +160,9 @@ export function RotatorPlugin() {
                   className={`glass-button px-2 py-1 text-xs ${
                     Math.abs(currentAzimuth - preset.azimuth) < 5 ? 'border-accent-primary text-accent-primary' : ''
                   }`}
-                  title={`${preset.azimuth}°`}
+                  title={`${preset.azimuth}\u00B0`}
                 >
-                  <span className="font-medium">{preset.name}</span>
+                  <span className="font-ui font-medium">{preset.name}</span>
                 </button>
               ))}
 
@@ -174,10 +174,10 @@ export function RotatorPlugin() {
                 <div className="flex rounded overflow-hidden border border-glass-200 text-xs">
                   <button
                     onClick={() => setPathMode('short')}
-                    className={`px-2 py-1 font-medium transition-colors ${
+                    className={`px-2 py-1 font-ui font-medium transition-colors ${
                       pathMode === 'short'
                         ? 'bg-accent-warning text-dark-900'
-                        : 'bg-dark-700 text-gray-400 hover:text-gray-200'
+                        : 'bg-dark-700 text-dark-300 hover:text-dark-200'
                     }`}
                     title="Short Path"
                   >
@@ -185,10 +185,10 @@ export function RotatorPlugin() {
                   </button>
                   <button
                     onClick={() => setPathMode('long')}
-                    className={`px-2 py-1 font-medium transition-colors ${
+                    className={`px-2 py-1 font-ui font-medium transition-colors ${
                       pathMode === 'long'
                         ? 'bg-accent-warning text-dark-900'
-                        : 'bg-dark-700 text-gray-400 hover:text-gray-200'
+                        : 'bg-dark-700 text-dark-300 hover:text-dark-200'
                     }`}
                     title="Long Path"
                   >
@@ -232,7 +232,7 @@ export function RotatorPlugin() {
                     title={`Rotate to ${focusedCallsignInfo?.callsign} (${pathMode === 'short' ? 'SP' : 'LP'})`}
                   >
                     <Target className="w-3.5 h-3.5" />
-                    <span className="font-mono">{selectedBearing?.toFixed(0)}°</span>
+                    <span className="font-mono">{selectedBearing?.toFixed(0)}\u00B0</span>
                   </button>
                 </>
               )}
@@ -252,7 +252,7 @@ export function RotatorPlugin() {
               </button>
             </>
           ) : (
-            <span className="text-sm text-gray-500">Disabled</span>
+            <span className="text-sm font-ui text-dark-300">Disabled</span>
           )}
         </div>
       }
@@ -260,9 +260,9 @@ export function RotatorPlugin() {
       {/* Disabled state */}
       {!rotatorEnabled && (
         <div className="p-8 flex flex-col items-center justify-center text-center">
-          <Compass className="w-16 h-16 text-gray-600 mb-4" />
-          <p className="text-gray-400 text-lg font-medium mb-2">Rotator Disabled</p>
-          <p className="text-gray-500 text-sm">
+          <Compass className="w-16 h-16 text-dark-400 mb-4" />
+          <p className="text-dark-300 text-lg font-ui font-medium mb-2">Rotator Disabled</p>
+          <p className="text-dark-300 text-sm font-ui">
             Enable rotator in Settings to control antenna direction.
           </p>
         </div>
@@ -302,7 +302,7 @@ export function RotatorPlugin() {
                 {/* Inner decorative ring */}
                 <div className="absolute inset-4 rounded-full border border-glass-100" />
 
-                {/* Degree markers - major (every 30°) */}
+                {/* Degree markers - major (every 30deg) */}
                 {[0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330].map((deg) => (
                   <div
                     key={`major-${deg}`}
@@ -316,7 +316,7 @@ export function RotatorPlugin() {
                   />
                 ))}
 
-                {/* Degree markers - minor (every 10°) */}
+                {/* Degree markers - minor (every 10deg) */}
                 {[10, 20, 40, 50, 70, 80, 100, 110, 130, 140, 160, 170, 190, 200, 220, 230, 250, 260, 280, 290, 310, 320, 340, 350].map((deg) => (
                   <div
                     key={`minor-${deg}`}
@@ -331,36 +331,36 @@ export function RotatorPlugin() {
                 ))}
 
                 {/* Cardinal directions */}
-                <span className="absolute top-5 left-1/2 -translate-x-1/2 text-sm font-bold text-accent-danger">N</span>
-                <span className="absolute bottom-5 left-1/2 -translate-x-1/2 text-sm font-bold text-gray-500">S</span>
-                <span className="absolute left-5 top-1/2 -translate-y-1/2 text-sm font-bold text-gray-500">W</span>
-                <span className="absolute right-5 top-1/2 -translate-y-1/2 text-sm font-bold text-gray-500">E</span>
+                <span className="absolute top-5 left-1/2 -translate-x-1/2 text-sm font-bold text-accent-danger font-display">N</span>
+                <span className="absolute bottom-5 left-1/2 -translate-x-1/2 text-sm font-bold text-dark-300 font-display">S</span>
+                <span className="absolute left-5 top-1/2 -translate-y-1/2 text-sm font-bold text-dark-300 font-display">W</span>
+                <span className="absolute right-5 top-1/2 -translate-y-1/2 text-sm font-bold text-dark-300 font-display">E</span>
 
                 {/* Intercardinal directions */}
-                <span className="absolute top-8 right-8 text-xs text-gray-600">NE</span>
-                <span className="absolute top-8 left-8 text-xs text-gray-600">NW</span>
-                <span className="absolute bottom-8 right-8 text-xs text-gray-600">SE</span>
-                <span className="absolute bottom-8 left-8 text-xs text-gray-600">SW</span>
+                <span className="absolute top-8 right-8 text-xs text-dark-400 font-mono">NE</span>
+                <span className="absolute top-8 left-8 text-xs text-dark-400 font-mono">NW</span>
+                <span className="absolute bottom-8 right-8 text-xs text-dark-400 font-mono">SE</span>
+                <span className="absolute bottom-8 left-8 text-xs text-dark-400 font-mono">SW</span>
 
-                {/* Short path bearing indicator (orange line) */}
+                {/* Short path bearing indicator (amber line) */}
                 {shortPathBearing != null && (
                   <div
                     className="absolute left-1/2 top-1/2 w-1 h-24 -ml-0.5 origin-bottom"
                     style={{
                       transform: `translateY(-100%) rotate(${shortPathBearing}deg)`,
-                      background: 'linear-gradient(to top, transparent, #f97316)',
+                      background: 'linear-gradient(to top, transparent, #ffb432)',
                       opacity: pathMode === 'short' ? 0.8 : 0.3,
                     }}
                   />
                 )}
 
-                {/* Long path bearing indicator (orange dashed line) */}
+                {/* Long path bearing indicator (amber dashed line) */}
                 {longPathBearing != null && (
                   <div
                     className="absolute left-1/2 top-1/2 w-0.5 h-24 origin-bottom"
                     style={{
                       transform: `translateY(-100%) rotate(${longPathBearing}deg)`,
-                      background: `repeating-linear-gradient(to top, transparent 0px, transparent 4px, #f97316 4px, #f97316 8px)`,
+                      background: `repeating-linear-gradient(to top, transparent 0px, transparent 4px, #ffb432 4px, #ffb432 8px)`,
                       opacity: pathMode === 'long' ? 0.8 : 0.3,
                     }}
                   />
@@ -376,7 +376,7 @@ export function RotatorPlugin() {
                   <div
                     className="w-full h-full rounded-full"
                     style={{
-                      background: 'linear-gradient(to top, transparent 0%, #6366f1 30%, #8b5cf6 100%)',
+                      background: 'linear-gradient(to top, transparent 0%, #00ddff 30%, #00ff88 100%)',
                     }}
                   />
                   {/* Needle tip glow */}
@@ -390,14 +390,14 @@ export function RotatorPlugin() {
 
                 {/* Azimuth display */}
                 <div className="absolute left-1/2 top-1/2 -translate-x-1/2 translate-y-10 text-center">
-                  <span className="text-3xl font-mono font-bold text-accent-primary drop-shadow-glow">
-                    {currentAzimuth.toFixed(0)}°
+                  <span className="text-3xl font-display font-bold text-accent-primary drop-shadow-glow">
+                    {currentAzimuth.toFixed(0)}&deg;
                   </span>
                 </div>
 
                 {/* Moving indicator */}
                 {rotatorPosition?.isMoving && (
-                  <div className="absolute left-1/2 -bottom-2 -translate-x-1/2 flex items-center gap-1 text-xs text-accent-warning">
+                  <div className="absolute left-1/2 -bottom-2 -translate-x-1/2 flex items-center gap-1 text-xs text-accent-warning font-ui">
                     <RotateCw className="w-3 h-3 animate-spin" />
                     <span>Moving</span>
                   </div>
@@ -416,15 +416,15 @@ export function RotatorPlugin() {
                 {focusedCallsignInfo.callsign}
               </span>
               {focusedCallsignInfo.grid && (
-                <span className="text-gray-500">{focusedCallsignInfo.grid}</span>
+                <span className="text-dark-300 font-mono">{focusedCallsignInfo.grid}</span>
               )}
             </div>
             <div className="flex items-center gap-3 font-mono">
-              <span className={pathMode === 'short' ? 'text-accent-warning' : 'text-gray-500'}>
-                SP {shortPathBearing?.toFixed(0) ?? '---'}°
+              <span className={pathMode === 'short' ? 'text-accent-warning' : 'text-dark-300'}>
+                SP {shortPathBearing?.toFixed(0) ?? '---'}&deg;
               </span>
-              <span className={pathMode === 'long' ? 'text-accent-warning' : 'text-gray-500'}>
-                LP {longPathBearing?.toFixed(0) ?? '---'}°
+              <span className={pathMode === 'long' ? 'text-accent-warning' : 'text-dark-300'}>
+                LP {longPathBearing?.toFixed(0) ?? '---'}&deg;
               </span>
               {focusedCallsignInfo.distance != null && (
                 <span className="text-accent-info">
@@ -437,9 +437,9 @@ export function RotatorPlugin() {
 
         {/* Status line - only show when moving */}
         {rotatorPosition?.isMoving && rotatorPosition?.targetAzimuth != null && (
-          <div className="flex items-center justify-center text-xs text-accent-warning gap-1">
+          <div className="flex items-center justify-center text-xs text-accent-warning font-ui gap-1">
             <RotateCw className="w-3 h-3 animate-spin" />
-            <span>Moving to {rotatorPosition.targetAzimuth.toFixed(0)}°</span>
+            <span>Moving to {rotatorPosition.targetAzimuth.toFixed(0)}&deg;</span>
           </div>
         )}
       </div>
@@ -496,24 +496,24 @@ function RotatorSettingsModal({ presets, onSave, onClose }: RotatorSettingsModal
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-dark-800 rounded-xl border border-glass-100 shadow-2xl w-full max-w-md mx-4">
         <div className="flex items-center justify-between px-4 py-3 border-b border-glass-100">
-          <h3 className="text-lg font-semibold text-gray-200">Rotator Presets</h3>
+          <h3 className="text-lg font-ui font-semibold text-dark-200">Rotator Presets</h3>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-200 transition-colors"
+            className="text-dark-300 hover:text-dark-200 transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
         </div>
 
         <div className="p-4 space-y-4">
-          <p className="text-sm text-gray-400">
-            Configure quick-access heading presets. Examples: N (0°), VK LP (240°), JA SP (30°)
+          <p className="text-sm font-ui text-dark-300">
+            Configure quick-access heading presets. Examples: N (0&deg;), VK LP (240&deg;), JA SP (30&deg;)
           </p>
 
           <div className="space-y-3">
             {editedPresets.map((preset, index) => (
               <div key={index} className="flex items-center gap-3">
-                <span className="text-sm text-gray-500 w-6">{index + 1}.</span>
+                <span className="text-sm text-dark-300 font-mono w-6">{index + 1}.</span>
                 <input
                   type="text"
                   value={preset.name}
@@ -531,19 +531,19 @@ function RotatorSettingsModal({ presets, onSave, onClose }: RotatorSettingsModal
                     max="360"
                     className="glass-input w-20 text-sm font-mono text-center"
                   />
-                  <span className="text-gray-500 text-sm">°</span>
+                  <span className="text-dark-300 text-sm">&deg;</span>
                 </div>
               </div>
             ))}
           </div>
 
-          <div className="text-xs text-gray-500 pt-2 border-t border-glass-50">
-            <p className="font-medium mb-1">Example configurations:</p>
-            <ul className="space-y-0.5 list-disc list-inside">
-              <li>NA (290°) - North America</li>
-              <li>VK LP (240°) - VK Long Path</li>
-              <li>VK SP (60°) - VK Short Path</li>
-              <li>JA SP (30°) - Japan Short Path</li>
+          <div className="text-xs text-dark-300 pt-2 border-t border-glass-100">
+            <p className="font-ui font-medium mb-1">Example configurations:</p>
+            <ul className="space-y-0.5 list-disc list-inside font-mono">
+              <li>NA (290&deg;) - North America</li>
+              <li>VK LP (240&deg;) - VK Long Path</li>
+              <li>VK SP (60&deg;) - VK Short Path</li>
+              <li>JA SP (30&deg;) - Japan Short Path</li>
             </ul>
           </div>
         </div>
@@ -551,20 +551,20 @@ function RotatorSettingsModal({ presets, onSave, onClose }: RotatorSettingsModal
         <div className="flex justify-between gap-2 px-4 py-3 border-t border-glass-100">
           <button
             onClick={handleReset}
-            className="px-3 py-2 text-sm font-medium text-gray-400 hover:text-gray-200 transition-colors"
+            className="px-3 py-2 text-sm font-ui font-medium text-dark-300 hover:text-dark-200 transition-colors"
           >
             Reset to N/E/S/W
           </button>
           <div className="flex gap-2">
             <button
               onClick={onClose}
-              className="px-4 py-2 text-sm font-medium bg-dark-700 text-gray-300 rounded-lg hover:bg-dark-600 transition-all border border-glass-100"
+              className="px-4 py-2 text-sm font-ui font-medium bg-dark-700 text-dark-200 rounded-lg hover:bg-dark-600 transition-all border border-glass-100"
             >
               Cancel
             </button>
             <button
               onClick={() => onSave(editedPresets)}
-              className="px-4 py-2 text-sm font-medium bg-accent-primary text-white rounded-lg hover:bg-accent-primary/80 transition-all"
+              className="px-4 py-2 text-sm font-ui font-medium bg-accent-primary text-white rounded-lg hover:bg-accent-primary/80 transition-all"
             >
               Save
             </button>

--- a/src/Log4YM.Web/src/plugins/SmartUnlinkPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/SmartUnlinkPlugin.tsx
@@ -120,10 +120,10 @@ export function SmartUnlinkPlugin() {
     >
       <div className="p-4 space-y-3">
         {radios.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-8 text-gray-500">
+          <div className="flex flex-col items-center justify-center py-8 text-dark-300">
             <WifiOff className="w-12 h-12 mb-4 opacity-50" />
-            <p className="text-center">No radios configured</p>
-            <p className="text-sm text-gray-600 mt-2 text-center">
+            <p className="font-ui text-center">No radios configured</p>
+            <p className="text-sm text-dark-300 mt-2 text-center">
               Add a FlexRadio to broadcast discovery packets
             </p>
           </div>
@@ -147,7 +147,7 @@ export function SmartUnlinkPlugin() {
             <div className="flex items-center justify-between px-4 py-3 border-b border-glass-100">
               <div className="flex items-center gap-2">
                 <Radio className="w-5 h-5 text-accent-primary" />
-                <h3 className="font-semibold">
+                <h3 className="font-ui font-semibold">
                   {isEditing ? 'Edit FlexRadio' : 'Add FlexRadio'}
                 </h3>
               </div>
@@ -162,48 +162,48 @@ export function SmartUnlinkPlugin() {
             <form onSubmit={handleSubmit} className="p-4 space-y-4">
               {/* Radio Name */}
               <div>
-                <label className="block text-xs text-gray-400 mb-1">
-                  Radio Name <span className="text-red-400">*</span>
+                <label className="block text-xs font-ui text-dark-300 mb-1">
+                  Radio Name <span className="text-accent-danger">*</span>
                 </label>
                 <input
                   type="text"
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm focus:outline-none focus:border-accent-primary"
+                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:border-accent-primary"
                   placeholder="My Flex 6600"
                 />
               </div>
 
               {/* IP Address */}
               <div>
-                <label className="block text-xs text-gray-400 mb-1">
-                  IP Address <span className="text-red-400">*</span>
+                <label className="block text-xs font-ui text-dark-300 mb-1">
+                  IP Address <span className="text-accent-danger">*</span>
                 </label>
                 <input
                   type="text"
                   value={formData.ipAddress}
                   onChange={(e) => setFormData({ ...formData, ipAddress: e.target.value })}
-                  className={`w-full bg-dark-700 border rounded px-3 py-2 text-sm focus:outline-none ${
+                  className={`w-full bg-dark-700 border rounded px-3 py-2 text-sm font-mono focus:outline-none ${
                     formData.ipAddress && !validateIp(formData.ipAddress)
-                      ? 'border-red-500 focus:border-red-500'
+                      ? 'border-accent-danger focus:border-accent-danger'
                       : 'border-glass-100 focus:border-accent-primary'
                   }`}
                   placeholder="192.168.1.100"
                 />
                 {formData.ipAddress && !validateIp(formData.ipAddress) && (
-                  <p className="text-xs text-red-400 mt-1">Invalid IP address format</p>
+                  <p className="text-xs text-accent-danger mt-1">Invalid IP address format</p>
                 )}
               </div>
 
               {/* Model */}
               <div>
-                <label className="block text-xs text-gray-400 mb-1">
-                  Model <span className="text-red-400">*</span>
+                <label className="block text-xs font-ui text-dark-300 mb-1">
+                  Model <span className="text-accent-danger">*</span>
                 </label>
                 <select
                   value={formData.model}
                   onChange={(e) => setFormData({ ...formData, model: e.target.value })}
-                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm focus:outline-none focus:border-accent-primary"
+                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:border-accent-primary"
                 >
                   {FLEX_RADIO_MODELS.map((model) => (
                     <option key={model} value={model}>
@@ -215,31 +215,31 @@ export function SmartUnlinkPlugin() {
 
               {/* Callsign */}
               <div>
-                <label className="block text-xs text-gray-400 mb-1">
-                  Callsign <span className="text-gray-500">(optional)</span>
+                <label className="block text-xs font-ui text-dark-300 mb-1">
+                  Callsign <span className="text-dark-300">(optional)</span>
                 </label>
                 <input
                   type="text"
                   value={formData.callsign}
                   onChange={(e) => setFormData({ ...formData, callsign: e.target.value.toUpperCase() })}
-                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm focus:outline-none focus:border-accent-primary uppercase"
+                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:border-accent-primary uppercase"
                   placeholder="W1ABC"
                 />
               </div>
 
               {/* Version */}
               <div>
-                <label className="block text-xs text-gray-400 mb-1">
-                  Firmware Version <span className="text-gray-500">(optional)</span>
+                <label className="block text-xs font-ui text-dark-300 mb-1">
+                  Firmware Version <span className="text-dark-300">(optional)</span>
                 </label>
                 <input
                   type="text"
                   value={formData.version}
                   onChange={(e) => setFormData({ ...formData, version: e.target.value })}
-                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm focus:outline-none focus:border-accent-primary"
+                  className="w-full bg-dark-700 border border-glass-100 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:border-accent-primary"
                   placeholder="4.1.3.39644"
                 />
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-dark-300 mt-1">
                   SmartSDR version to advertise (must match your SmartSDR app version)
                 </p>
               </div>
@@ -249,7 +249,7 @@ export function SmartUnlinkPlugin() {
                 <button
                   type="button"
                   onClick={() => setShowModal(false)}
-                  className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+                  className="px-4 py-2 text-sm text-dark-300 hover:text-white transition-colors"
                 >
                   Cancel
                 </button>
@@ -294,20 +294,20 @@ function RadioCard({ radio, onEdit, onDelete, onToggleEnabled }: RadioCardProps)
       {/* Header */}
       <div className="flex items-start justify-between mb-2">
         <div>
-          <div className="font-medium text-gray-200">{radio.name}</div>
-          <div className="text-xs text-gray-500">{radio.model}</div>
+          <div className="font-mono font-medium text-dark-200">{radio.name}</div>
+          <div className="text-xs font-mono text-dark-300">{radio.model}</div>
         </div>
         <div className="flex items-center gap-1">
           <button
             onClick={onEdit}
-            className="p-1.5 hover:bg-dark-600 rounded transition-colors text-gray-400 hover:text-white"
+            className="p-1.5 hover:bg-dark-600 rounded transition-colors text-dark-300 hover:text-white"
             title="Edit"
           >
             <Pencil className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={onDelete}
-            className="p-1.5 hover:bg-dark-600 rounded transition-colors text-gray-400 hover:text-red-400"
+            className="p-1.5 hover:bg-dark-600 rounded transition-colors text-dark-300 hover:text-accent-danger"
             title="Delete"
           >
             <Trash2 className="w-3.5 h-3.5" />
@@ -316,14 +316,14 @@ function RadioCard({ radio, onEdit, onDelete, onToggleEnabled }: RadioCardProps)
       </div>
 
       {/* Info */}
-      <div className="text-sm text-gray-400 space-y-1 mb-3">
+      <div className="text-sm text-dark-300 space-y-1 mb-3">
         <div className="flex items-center gap-2">
           <Wifi className="w-3.5 h-3.5" />
           <span className="font-mono">{radio.ipAddress}</span>
           {radio.callsign && (
             <>
-              <span className="text-gray-600">|</span>
-              <span>{radio.callsign}</span>
+              <span className="text-dark-300">|</span>
+              <span className="font-mono">{radio.callsign}</span>
             </>
           )}
         </div>
@@ -333,13 +333,13 @@ function RadioCard({ radio, onEdit, onDelete, onToggleEnabled }: RadioCardProps)
       <div className="flex items-center justify-between pt-2 border-t border-glass-100">
         <div className="flex items-center gap-2">
           {radio.enabled ? (
-            <span className="flex items-center gap-1.5 text-xs text-accent-success">
+            <span className="flex items-center gap-1.5 text-xs font-mono text-accent-success">
               <span className="w-2 h-2 rounded-full bg-accent-success animate-pulse" />
               Broadcasting
             </span>
           ) : (
-            <span className="flex items-center gap-1.5 text-xs text-gray-500">
-              <span className="w-2 h-2 rounded-full bg-gray-600" />
+            <span className="flex items-center gap-1.5 text-xs font-mono text-dark-300">
+              <span className="w-2 h-2 rounded-full bg-dark-600" />
               Idle
             </span>
           )}
@@ -348,10 +348,10 @@ function RadioCard({ radio, onEdit, onDelete, onToggleEnabled }: RadioCardProps)
         <button
           onClick={onToggleEnabled}
           className={`
-            flex items-center gap-1.5 px-2 py-1 text-xs rounded transition-all
+            flex items-center gap-1.5 px-2 py-1 text-xs font-mono rounded transition-all
             ${radio.enabled
-              ? 'bg-green-500/20 text-green-400 hover:bg-green-500/30'
-              : 'bg-dark-600 text-gray-400 hover:bg-dark-500'
+              ? 'bg-accent-success/20 text-accent-success hover:bg-accent-success/30'
+              : 'bg-dark-600 text-dark-300 hover:bg-dark-500'
             }
           `}
         >

--- a/src/Log4YM.Web/tailwind.config.js
+++ b/src/Log4YM.Web/tailwind.config.js
@@ -7,47 +7,54 @@ export default {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        display: ['Orbitron', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'Consolas', 'monospace'],
+        ui: ['Space Grotesk', 'system-ui', 'sans-serif'],
+      },
       colors: {
-        // VS Code Dark Modern inspired palette
+        // OpenHamClock instrument panel palette
         glass: {
-          50: 'rgba(255, 255, 255, 0.04)',
-          100: 'rgba(255, 255, 255, 0.06)',
-          200: 'rgba(255, 255, 255, 0.08)',
-          300: 'rgba(255, 255, 255, 0.12)',
+          50: 'rgba(255, 180, 50, 0.04)',
+          100: 'rgba(255, 180, 50, 0.08)',
+          200: 'rgba(255, 180, 50, 0.12)',
+          300: 'rgba(255, 180, 50, 0.18)',
         },
         dark: {
-          900: '#1e1e1e',        // VS Code editor background
-          850: '#212122',        // Between 900 and 800
-          800: '#252526',        // VS Code sidebar background
-          700: '#2d2d2d',        // VS Code hover/selection
-          600: '#3c3c3c',        // VS Code border/divider
-          500: '#4d4d4d',        // Lighter elements
-          400: '#5a5a5a',        // Even lighter
-          300: '#6e6e6e',        // Muted text
+          900: '#0a0e14',        // Deepest background
+          850: '#0e1319',        // Between 900 and 800
+          800: '#111820',        // Panel/sidebar background
+          700: '#1a2332',        // Elevated surface
+          600: '#243044',        // Borders, dividers
+          500: '#2e3d55',        // Lighter elements
+          400: '#3d5070',        // Muted interactive
+          300: '#5a7090',        // Muted text
+          200: '#8899aa',        // Secondary text
         },
         accent: {
-          primary: '#0078d4',    // VS Code blue (focus/selection)
-          secondary: '#3794ff',  // Lighter blue
-          success: '#4ec9b0',    // VS Code teal/cyan
-          warning: '#dcdcaa',    // VS Code yellow
-          danger: '#f14c4c',     // VS Code red
-          info: '#9cdcfe',       // VS Code light blue
+          primary: '#ffb432',    // Amber — signature accent
+          secondary: '#00ddff',  // Cyan — secondary accent
+          success: '#00ff88',    // Green — section headers, good status
+          warning: '#ffb432',    // Amber — warnings
+          danger: '#ff4466',     // Red — alerts, errors
+          info: '#00ddff',       // Cyan — informational
         },
         ham: {
-          cw: '#dcdcaa',         // Yellow for CW
-          ssb: '#4ec9b0',        // Teal for SSB
-          ft8: '#569cd6',        // Blue for FT8
-          rtty: '#c586c0',       // Pink/magenta for RTTY
+          cw: '#ffb432',         // Amber for CW
+          ssb: '#00ff88',        // Green for SSB
+          ft8: '#00ddff',        // Cyan for FT8
+          rtty: '#aa66ff',       // Purple for RTTY
         }
       },
       backdropBlur: {
         xs: '2px',
       },
       boxShadow: {
-        'glass': '0 8px 32px 0 rgba(0, 0, 0, 0.5)',
-        'glass-sm': '0 4px 16px 0 rgba(0, 0, 0, 0.35)',
-        'glow': '0 0 20px rgba(0, 120, 212, 0.3)',
-        'glow-success': '0 0 20px rgba(78, 201, 176, 0.3)',
+        'glass': '0 8px 32px 0 rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 180, 50, 0.05)',
+        'glass-sm': '0 4px 16px 0 rgba(0, 0, 0, 0.4)',
+        'glow': '0 0 20px rgba(255, 180, 50, 0.25)',
+        'glow-success': '0 0 20px rgba(0, 255, 136, 0.25)',
+        'glow-cyan': '0 0 20px rgba(0, 221, 255, 0.25)',
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
@@ -59,8 +66,8 @@ export default {
       },
       keyframes: {
         glow: {
-          '0%': { boxShadow: '0 0 5px rgba(0, 120, 212, 0.2)' },
-          '100%': { boxShadow: '0 0 20px rgba(0, 120, 212, 0.4)' },
+          '0%': { boxShadow: '0 0 5px rgba(255, 180, 50, 0.15)' },
+          '100%': { boxShadow: '0 0 20px rgba(255, 180, 50, 0.35)' },
         }
       }
     },


### PR DESCRIPTION
## Summary
- Restyled entire frontend from VS Code-inspired theme to OpenHamClock's dockable dark instrument panel design
- Updated all 21 files: tailwind config, index.html (fonts), index.css, 6 components, and 13 plugins
- New palette: dark blue-black backgrounds (#0a0e14), amber (#ffb432) + cyan (#00ddff) accent pair, green (#00ff88) headers, red (#ff4466) alerts
- Typography: Orbitron for numeric readouts, JetBrains Mono for data, Space Grotesk for UI text
- Glassmorphic panels with amber-tinted borders, cyan hover states, subtle CRT scanline overlay
- Leaflet satellite map tile layer preserved unchanged

## Test plan
- [ ] Verify all panels render with correct OpenHamClock colors and fonts
- [ ] Check DX Cluster AG Grid styling (green headers, cyan hover, amber selections)
- [ ] Confirm Log History AG Grid and modals use new palette
- [ ] Verify 3D Globe and 2D Map markers/overlays use new colors
- [ ] Check Rotator SVG compass uses amber/cyan colors
- [ ] Verify Analog Clock SVG uses amber hands and cyan second hand
- [ ] Confirm Settings Panel sidebar and all sections use new palette
- [ ] Test Rig Plugin TCI/Hamlib forms use correct accent colors
- [ ] Verify PGXL meter gauges use new color scale
- [ ] Check StatusBar and ConnectionOverlay styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)