### PR TITLE
fix(map): invalidate Leaflet map size on panel resize

### DIFF
--- a/src/Log4YM.Web/src/plugins/MapPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/MapPlugin.tsx
@@ -237,6 +237,21 @@ export function MapPlugin() {
     });
   }, [focusedCallsignInfo?.latitude, focusedCallsignInfo?.longitude, stationLat, stationLon]);
 
+  // Invalidate map size when container is resized (e.g., FlexLayout panel drag)
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver(() => {
+      requestAnimationFrame(() => {
+        mapRef.current?.invalidateSize();
+      });
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
   // Handle click on map to set bearing (only when rotator enabled)
   const handleBearingClick = useCallback((azimuth: number) => {
     if (!rotatorEnabled) return; // Ignore clicks when rotator disabled


### PR DESCRIPTION
## Summary
- Adds a `ResizeObserver` to the MapPlugin container that calls `map.invalidateSize()` when the container dimensions change
- Fixes Leaflet 2D map not redrawing properly when FlexLayout panels are resized or rearranged

## Test plan
- [ ] Drag FlexLayout splitters adjacent to the 2D map panel — map should redraw tiles correctly
- [ ] Move/rearrange the map panel to a different dock position — map should fill the new container
- [ ] Verify no console errors from the ResizeObserver