### PR TITLE
Fix DX news ticker animation to match OpenHamClock

### DIFF
--- a/src/Log4YM.Web/src/index.css
+++ b/src/Log4YM.Web/src/index.css
@@ -475,12 +475,8 @@
   z-index: 9999;
 }
 
-/* Scrolling ticker animation */
-@keyframes scroll {
+/* DX News ticker scrolling animation */
+@keyframes dxnews-scroll {
   0% { transform: translateX(0); }
   100% { transform: translateX(-50%); }
-}
-
-.animate-scroll {
-  animation-name: scroll;
 }


### PR DESCRIPTION
## Summary
- Rewrote ticker animation to use state-driven duration instead of ref mutation, fixing the ticker not scrolling
- Matched OpenHamClock scroll speed (~90px/s) and cadence with `paddingLeft: 100%` for right-to-left entry
- Used CSS mask gradient for fade edges and renamed keyframe to `dxnews-scroll`

## Test plan
- [ ] Open Map 2D panel and verify news ticker scrolls smoothly at bottom
- [ ] Verify text enters from the right edge and loops seamlessly