### PR TITLE
feat: implement light/dark/system theme switching

### DIFF
--- a/src/Log4YM.Web/index.html
+++ b/src/Log4YM.Web/index.html
@@ -10,10 +10,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <style>
-      /* Prevent flash of unstyled content */
-      html {
-        background-color: #0a0e14;
-      }
+      /* Prevent flash of unstyled content — matches dark theme default */
+      html.dark { background-color: #0a0e14; }
+      html:not(.dark) { background-color: #f6f7f9; }
     </style>
   </head>
   <body class="bg-dark-900">

--- a/src/Log4YM.Web/src/App.tsx
+++ b/src/Log4YM.Web/src/App.tsx
@@ -11,6 +11,7 @@ import { useLayoutStore, defaultLayout } from './store/layoutStore';
 import { useSettingsStore } from './store/settingsStore';
 import { useSetupStore } from './store/setupStore';
 import { useAppStore } from './store/appStore';
+import { useTheme } from './hooks/useTheme';
 
 import 'flexlayout-react/style/dark.css';
 
@@ -118,6 +119,9 @@ export function App() {
   const [model, setModel] = useState<Model>(() => Model.fromJson(layout));
   const [showPanelPicker, setShowPanelPicker] = useState(false);
   const [targetTabSetId, setTargetTabSetId] = useState<string | null>(null);
+
+  // Apply theme from settings (dark/light/system)
+  useTheme();
 
   // Check setup status on mount (for status display, not blocking)
   useEffect(() => {

--- a/src/Log4YM.Web/src/components/SettingsPanel.tsx
+++ b/src/Log4YM.Web/src/components/SettingsPanel.tsx
@@ -23,6 +23,9 @@ import {
   Server,
   ExternalLink,
   Bot,
+  Sun,
+  Moon,
+  Monitor,
 } from 'lucide-react';
 import { useSettingsStore, SettingsSection } from '../store/settingsStore';
 import { useSetupStore } from '../store/setupStore';
@@ -778,6 +781,30 @@ function AppearanceSettingsSection() {
   const { settings, updateAppearanceSettings } = useSettingsStore();
   const appearance = settings.appearance;
 
+  const themeOptions = [
+    {
+      id: 'dark' as const,
+      label: 'Dark',
+      icon: <Moon className="w-5 h-5" />,
+      description: 'Instrument panel aesthetic',
+      preview: { bg: '#0a0e14', panel: '#111820', accent: '#ffb432', text: '#a0b0c0' },
+    },
+    {
+      id: 'light' as const,
+      label: 'Light',
+      icon: <Sun className="w-5 h-5" />,
+      description: 'Clean, minimal design',
+      preview: { bg: '#f6f7f9', panel: '#ffffff', accent: '#4a3d8f', text: '#4b5563' },
+    },
+    {
+      id: 'system' as const,
+      label: 'System',
+      icon: <Monitor className="w-5 h-5" />,
+      description: 'Follow OS preference',
+      preview: null,
+    },
+  ];
+
   return (
     <div className="space-y-6">
       <div>
@@ -789,21 +816,47 @@ function AppearanceSettingsSection() {
       <div className="space-y-3">
         <label className="text-sm font-medium font-ui text-dark-200">Theme</label>
         <div className="grid grid-cols-3 gap-3">
-          {(['dark', 'light', 'system'] as const).map((theme) => (
+          {themeOptions.map((opt) => (
             <button
-              key={theme}
-              onClick={() => updateAppearanceSettings({ theme })}
-              className={`p-4 rounded-lg border transition-all ${
-                appearance.theme === theme
-                  ? 'border-accent-primary bg-accent-primary/10'
+              key={opt.id}
+              onClick={() => updateAppearanceSettings({ theme: opt.id })}
+              className={`relative flex flex-col items-center gap-3 p-4 rounded-lg border transition-all ${
+                appearance.theme === opt.id
+                  ? 'border-accent-primary bg-accent-primary/10 ring-1 ring-accent-primary/30'
                   : 'border-glass-100 hover:border-glass-200'
               }`}
             >
-              <span className="capitalize text-sm font-medium">{theme}</span>
+              {/* Mini preview */}
+              {opt.preview ? (
+                <div
+                  className="w-full h-14 rounded-md border border-dark-600/50 overflow-hidden flex items-end p-1.5 gap-1"
+                  style={{ background: opt.preview.bg }}
+                >
+                  <div
+                    className="flex-1 h-8 rounded"
+                    style={{ background: opt.preview.panel, border: `1px solid ${opt.preview.accent}22` }}
+                  />
+                  <div
+                    className="w-6 h-8 rounded"
+                    style={{ background: opt.preview.panel, border: `1px solid ${opt.preview.accent}22` }}
+                  />
+                </div>
+              ) : (
+                <div className="w-full h-14 rounded-md border border-dark-600/50 overflow-hidden flex">
+                  <div className="w-1/2 h-full bg-[#0a0e14]" />
+                  <div className="w-1/2 h-full bg-[#f6f7f9]" />
+                </div>
+              )}
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <span className={appearance.theme === opt.id ? 'text-accent-primary' : 'text-dark-300'}>
+                  {opt.icon}
+                </span>
+                <span>{opt.label}</span>
+              </div>
+              <p className="text-xs text-dark-300">{opt.description}</p>
             </button>
           ))}
         </div>
-        <p className="text-xs text-dark-300">Currently only dark theme is available.</p>
       </div>
 
       {/* Compact mode toggle */}

--- a/src/Log4YM.Web/src/hooks/useTheme.ts
+++ b/src/Log4YM.Web/src/hooks/useTheme.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useSettingsStore } from '../store/settingsStore';
+
+/**
+ * Manages theme application based on user settings and system preference.
+ * Applies 'dark' class to <html> for dark mode, removes it for light mode.
+ * Listens to prefers-color-scheme media query when theme is set to 'system'.
+ */
+export function useTheme() {
+  const theme = useSettingsStore((s) => s.settings.appearance.theme);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const meta = document.querySelector('meta[name="theme-color"]');
+
+    const applyTheme = (resolved: 'dark' | 'light') => {
+      if (resolved === 'dark') {
+        html.classList.add('dark');
+      } else {
+        html.classList.remove('dark');
+      }
+      if (meta) {
+        meta.setAttribute('content', resolved === 'dark' ? '#0a0e14' : '#f6f7f9');
+      }
+    };
+
+    if (theme === 'system') {
+      const mq = window.matchMedia('(prefers-color-scheme: dark)');
+      const handler = (e: MediaQueryListEvent) => applyTheme(e.matches ? 'dark' : 'light');
+      applyTheme(mq.matches ? 'dark' : 'light');
+      mq.addEventListener('change', handler);
+      return () => mq.removeEventListener('change', handler);
+    }
+
+    applyTheme(theme);
+  }, [theme]);
+}

--- a/src/Log4YM.Web/src/index.css
+++ b/src/Log4YM.Web/src/index.css
@@ -2,6 +2,136 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================================
+   THEME VARIABLES
+   Light theme (default :root) and dark theme (.dark)
+   All colors use space-separated RGB for Tailwind alpha support
+   ============================================================ */
+
+:root {
+  /* Surface / background colors (maps to dark-* Tailwind classes) */
+  --surface-900: 246 247 249;     /* #f6f7f9 — deepest background */
+  --surface-850: 240 241 244;     /* #f0f1f4 */
+  --surface-800: 255 255 255;     /* #ffffff — panel background */
+  --surface-700: 243 244 246;     /* #f3f4f6 — elevated surface */
+  --surface-600: 216 220 227;     /* #d8dce3 — borders, dividers */
+  --surface-500: 192 199 209;     /* #c0c7d1 — lighter elements */
+  --surface-400: 156 163 175;     /* #9ca3af — muted interactive */
+  --surface-300: 107 114 128;     /* #6b7280 — muted text */
+  --surface-200: 55 65 81;        /* #374151 — secondary text */
+
+  /* Accent colors — deep indigo/purple for light theme */
+  --accent-primary: 74 61 143;    /* #4a3d8f */
+  --accent-secondary: 99 102 241; /* #6366f1 */
+  --accent-success: 5 150 105;    /* #059669 */
+  --accent-warning: 217 119 6;    /* #d97706 */
+  --accent-danger: 220 38 38;     /* #dc2626 */
+  --accent-info: 37 99 235;       /* #2563eb */
+
+  /* Ham radio mode colors */
+  --ham-cw: 180 83 9;             /* #b45309 */
+  --ham-ssb: 5 150 105;           /* #059669 */
+  --ham-ft8: 37 99 235;           /* #2563eb */
+  --ham-rtty: 124 58 237;         /* #7c3aed */
+
+  /* Gray scale — semantic (inverted for light mode so gray-100 = dark text) */
+  --gray-50: 17 24 39;
+  --gray-100: 31 41 55;
+  --gray-200: 55 65 81;
+  --gray-300: 75 85 99;
+  --gray-400: 107 114 128;
+  --gray-500: 156 163 175;
+  --gray-600: 209 213 219;
+  --gray-700: 229 231 235;
+  --gray-800: 243 244 246;
+  --gray-900: 249 250 251;
+
+  /* Text foreground */
+  --text-foreground: 75 85 99;    /* #4b5563 */
+
+  /* Shadows — soft, minimal for light theme */
+  --shadow-glass: 0 1px 3px 0 rgba(0, 0, 0, 0.07), 0 1px 2px -1px rgba(0, 0, 0, 0.05);
+  --shadow-glass-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.04);
+  --shadow-glow: 0 0 15px rgba(74, 61, 143, 0.12);
+  --shadow-glow-success: 0 0 15px rgba(5, 150, 105, 0.12);
+  --shadow-glow-cyan: 0 0 15px rgba(99, 102, 241, 0.12);
+
+  /* Scrollbar */
+  --scrollbar-track: #f3f4f6;
+  --scrollbar-thumb: #d1d5db;
+  --scrollbar-thumb-hover: #9ca3af;
+
+  /* Text glow — disabled in light mode */
+  --text-glow-primary: none;
+  --text-glow-secondary: none;
+
+  color-scheme: light;
+}
+
+.dark {
+  /* Surface / background colors */
+  --surface-900: 10 14 20;        /* #0a0e14 */
+  --surface-850: 14 19 25;        /* #0e1319 */
+  --surface-800: 17 24 32;        /* #111820 */
+  --surface-700: 26 35 50;        /* #1a2332 */
+  --surface-600: 36 48 68;        /* #243044 */
+  --surface-500: 46 61 85;        /* #2e3d55 */
+  --surface-400: 61 80 112;       /* #3d5070 */
+  --surface-300: 90 112 144;      /* #5a7090 */
+  --surface-200: 136 153 170;     /* #8899aa */
+
+  /* Accent colors — amber/cyan for dark theme */
+  --accent-primary: 255 180 50;   /* #ffb432 */
+  --accent-secondary: 0 221 255;  /* #00ddff */
+  --accent-success: 0 255 136;    /* #00ff88 */
+  --accent-warning: 255 180 50;   /* #ffb432 */
+  --accent-danger: 255 68 102;    /* #ff4466 */
+  --accent-info: 0 221 255;       /* #00ddff */
+
+  /* Ham radio mode colors */
+  --ham-cw: 255 180 50;           /* #ffb432 */
+  --ham-ssb: 0 255 136;           /* #00ff88 */
+  --ham-ft8: 0 221 255;           /* #00ddff */
+  --ham-rtty: 170 102 255;        /* #aa66ff */
+
+  /* Gray scale — standard Tailwind grays */
+  --gray-50: 249 250 251;
+  --gray-100: 243 244 246;
+  --gray-200: 229 231 235;
+  --gray-300: 209 213 219;
+  --gray-400: 156 163 175;
+  --gray-500: 107 114 128;
+  --gray-600: 75 85 99;
+  --gray-700: 55 65 81;
+  --gray-800: 31 41 55;
+  --gray-900: 17 24 39;
+
+  /* Text foreground */
+  --text-foreground: 160 176 192;  /* #a0b0c0 */
+
+  /* Shadows — dramatic for dark theme */
+  --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 180, 50, 0.05);
+  --shadow-glass-sm: 0 4px 16px 0 rgba(0, 0, 0, 0.4);
+  --shadow-glow: 0 0 20px rgba(255, 180, 50, 0.25);
+  --shadow-glow-success: 0 0 20px rgba(0, 255, 136, 0.25);
+  --shadow-glow-cyan: 0 0 20px rgba(0, 221, 255, 0.25);
+
+  /* Scrollbar */
+  --scrollbar-track: #0a0e14;
+  --scrollbar-thumb: #243044;
+  --scrollbar-thumb-hover: #2e3d55;
+
+  /* Text glow — enabled in dark mode */
+  --text-glow-primary: 0 0 12px rgb(var(--accent-primary) / 0.3);
+  --text-glow-secondary: 0 0 10px rgb(var(--accent-primary) / 0.2);
+
+  color-scheme: dark;
+}
+
+/* ============================================================
+   BASE LAYER
+   ============================================================ */
+
 @layer base {
   * {
     @apply border-glass-100;
@@ -12,28 +142,32 @@
     font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
   }
 
-  /* Custom scrollbar — dark instrument panel */
+  /* Custom scrollbar — themed */
   ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
   ::-webkit-scrollbar-track {
-    background: #0a0e14;
+    background: var(--scrollbar-track);
   }
 
   ::-webkit-scrollbar-thumb {
-    background: #243044;
+    background: var(--scrollbar-thumb);
     border-radius: 9999px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: #2e3d55;
+    background: var(--scrollbar-thumb-hover);
   }
 }
 
+/* ============================================================
+   COMPONENT LAYER
+   ============================================================ */
+
 @layer components {
-  /* Glassmorphic panel — OpenHamClock instrument style */
+  /* Glassmorphic panel — dark=glass, light=card */
   .glass-panel {
     @apply bg-dark-800/90 backdrop-blur-xl border border-glass-100 rounded-xl shadow-glass;
   }
@@ -42,7 +176,7 @@
     @apply bg-dark-800 border border-glass-100 rounded-xl shadow-glass;
   }
 
-  /* Glassmorphic input — amber-tinted focus */
+  /* Glassmorphic input — themed focus ring */
   .glass-input {
     @apply bg-dark-700/50 backdrop-blur-sm border border-glass-100 rounded-lg px-4 py-2
            text-gray-100 placeholder-gray-500
@@ -51,7 +185,7 @@
     font-family: 'JetBrains Mono', 'Consolas', monospace;
   }
 
-  /* Glassmorphic button — instrument panel */
+  /* Glassmorphic button — themed */
   .glass-button {
     @apply bg-dark-700/80 backdrop-blur-sm border border-glass-100 rounded-lg px-4 py-2
            text-gray-100 font-medium
@@ -126,19 +260,22 @@
   }
 
   .status-connected {
-    @apply bg-accent-success shadow-[0_0_8px_rgba(0,255,136,0.5)];
+    @apply bg-accent-success shadow-[0_0_8px_rgb(var(--accent-success)/0.5)];
   }
 
   .status-disconnected {
-    @apply bg-accent-danger shadow-[0_0_8px_rgba(255,68,102,0.5)];
+    @apply bg-accent-danger shadow-[0_0_8px_rgb(var(--accent-danger)/0.5)];
   }
 
   .status-warning {
-    @apply bg-accent-warning shadow-[0_0_8px_rgba(255,180,50,0.5)];
+    @apply bg-accent-warning shadow-[0_0_8px_rgb(var(--accent-warning)/0.5)];
   }
 }
 
-/* FlexLayout overrides — OpenHamClock dark instrument panel */
+/* ============================================================
+   FLEXLAYOUT OVERRIDES — themed via CSS custom properties
+   ============================================================ */
+
 .flexlayout__layout {
   @apply bg-transparent;
 }
@@ -146,7 +283,7 @@
 .flexlayout__tab_button {
   background: transparent;
   border-color: transparent;
-  color: #5a7090;
+  color: rgb(var(--surface-300));
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
   font-weight: 500;
@@ -155,47 +292,47 @@
 }
 
 .flexlayout__tab_button:hover {
-  color: #a0b0c0;
-  background: rgba(26, 35, 50, 0.6);
+  color: rgb(var(--text-foreground));
+  background: rgb(var(--surface-700) / 0.6);
 }
 
 .flexlayout__tab_button--selected {
-  background: #0a0e14;
-  color: #00ddff;
-  border-bottom: 2px solid #00ddff;
+  background: rgb(var(--surface-900));
+  color: rgb(var(--accent-secondary));
+  border-bottom: 2px solid rgb(var(--accent-secondary));
 }
 
 .flexlayout__tabset {
-  background: #111820;
-  border: 1px solid rgba(255, 180, 50, 0.1);
+  background: rgb(var(--surface-800));
+  border: 1px solid rgb(var(--accent-primary) / 0.1);
   border-radius: 8px 8px 0 0;
   overflow: hidden;
 }
 
 .flexlayout__tabset_tabbar_outer {
-  background: #111820;
-  border-bottom: 1px solid rgba(255, 180, 50, 0.1);
+  background: rgb(var(--surface-800));
+  border-bottom: 1px solid rgb(var(--accent-primary) / 0.1);
 }
 
 .flexlayout__tab {
-  background: #0a0e14;
+  background: rgb(var(--surface-900));
 }
 
 .flexlayout__splitter {
-  background: rgba(255, 180, 50, 0.08);
+  background: rgb(var(--accent-primary) / 0.08);
   transition: background 0.2s ease;
 }
 
 .flexlayout__splitter:hover {
-  background: rgba(0, 221, 255, 0.3);
+  background: rgb(var(--accent-secondary) / 0.3);
 }
 
 .flexlayout__border {
-  background: #111820;
+  background: rgb(var(--surface-800));
 }
 
 .flexlayout__tabset_header {
-  background: #111820;
+  background: rgb(var(--surface-800));
 }
 
 .flexlayout__tab_button_content {
@@ -207,83 +344,86 @@
 }
 
 .flexlayout__popup_menu {
-  background: #111820;
-  border: 1px solid rgba(255, 180, 50, 0.15);
+  background: rgb(var(--surface-800));
+  border: 1px solid rgb(var(--accent-primary) / 0.15);
   border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--shadow-glass);
 }
 
 .flexlayout__popup_menu_item {
   @apply px-4 py-2 cursor-pointer;
-  color: #a0b0c0;
+  color: rgb(var(--text-foreground));
   font-family: 'Space Grotesk', system-ui, sans-serif;
   transition: background 0.15s ease, color 0.15s ease;
 }
 
 .flexlayout__popup_menu_item:hover {
-  background: #1a2332;
-  color: #00ddff;
+  background: rgb(var(--surface-700));
+  color: rgb(var(--accent-secondary));
 }
 
 .flexlayout__drag_rect {
-  background: rgba(0, 221, 255, 0.1);
-  border: 2px dashed #00ddff;
+  background: rgb(var(--accent-secondary) / 0.1);
+  border: 2px dashed rgb(var(--accent-secondary));
   border-radius: 8px;
 }
 
 .flexlayout__outline_rect {
-  border: 2px solid #00ddff;
+  border: 2px solid rgb(var(--accent-secondary));
   border-radius: 8px;
 }
 
 .flexlayout__edge_rect {
-  background: rgba(0, 221, 255, 0.2);
+  background: rgb(var(--accent-secondary) / 0.2);
 }
 
 .flexlayout__tabset-selected {
-  box-shadow: inset 0 0 0 1px rgba(0, 221, 255, 0.3);
+  box-shadow: inset 0 0 0 1px rgb(var(--accent-secondary) / 0.3);
 }
 
 .flexlayout__tab_floating {
-  background: #111820;
-  border: 1px solid rgba(255, 180, 50, 0.15);
+  background: rgb(var(--surface-800));
+  border: 1px solid rgb(var(--accent-primary) / 0.15);
   border-radius: 8px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.7);
+  box-shadow: var(--shadow-glass);
 }
 
-/* AG Grid Dark Theme Overrides — OpenHamClock instrument panel */
+/* ============================================================
+   AG GRID OVERRIDES — themed via CSS custom properties
+   ============================================================ */
+
 .ag-theme-alpine-dark {
-  --ag-background-color: #0a0e14;
-  --ag-header-background-color: #111820;
-  --ag-odd-row-background-color: #0e1319;
-  --ag-row-hover-color: rgba(0, 221, 255, 0.06);
-  --ag-selected-row-background-color: rgba(255, 180, 50, 0.12);
-  --ag-border-color: rgba(255, 180, 50, 0.1);
-  --ag-header-foreground-color: #00ff88;
-  --ag-foreground-color: #a0b0c0;
-  --ag-row-border-color: rgba(255, 180, 50, 0.05);
+  --ag-background-color: rgb(var(--surface-900));
+  --ag-header-background-color: rgb(var(--surface-800));
+  --ag-odd-row-background-color: rgb(var(--surface-850));
+  --ag-row-hover-color: rgb(var(--accent-secondary) / 0.06);
+  --ag-selected-row-background-color: rgb(var(--accent-primary) / 0.12);
+  --ag-border-color: rgb(var(--accent-primary) / 0.1);
+  --ag-header-foreground-color: rgb(var(--accent-success));
+  --ag-foreground-color: rgb(var(--text-foreground));
+  --ag-row-border-color: rgb(var(--accent-primary) / 0.05);
   --ag-font-family: 'JetBrains Mono', 'Consolas', monospace;
   --ag-font-size: 13px;
   --ag-grid-size: 4px;
   --ag-cell-horizontal-padding: 12px;
-  --ag-header-column-separator-color: rgba(255, 180, 50, 0.1);
-  --ag-header-column-resize-handle-color: #00ddff;
-  --ag-range-selection-border-color: #00ddff;
-  --ag-input-focus-border-color: #ffb432;
-  --ag-checkbox-checked-color: #ffb432;
-  --ag-range-selection-background-color: rgba(0, 221, 255, 0.1);
+  --ag-header-column-separator-color: rgb(var(--accent-primary) / 0.1);
+  --ag-header-column-resize-handle-color: rgb(var(--accent-secondary));
+  --ag-range-selection-border-color: rgb(var(--accent-secondary));
+  --ag-input-focus-border-color: rgb(var(--accent-primary));
+  --ag-checkbox-checked-color: rgb(var(--accent-primary));
+  --ag-range-selection-background-color: rgb(var(--accent-secondary) / 0.1);
 }
 
 .ag-theme-alpine-dark .ag-root-wrapper {
-  background-color: #0a0e14;
-  border: 1px solid rgba(255, 180, 50, 0.1);
+  background-color: rgb(var(--surface-900));
+  border: 1px solid rgb(var(--accent-primary) / 0.1);
   border-radius: 4px;
   overflow: hidden;
 }
 
 .ag-theme-alpine-dark .ag-header {
-  background-color: #111820;
-  border-bottom: 1px solid rgba(255, 180, 50, 0.1);
+  background-color: rgb(var(--surface-800));
+  border-bottom: 1px solid rgb(var(--accent-primary) / 0.1);
 }
 
 .ag-theme-alpine-dark .ag-header-cell {
@@ -299,21 +439,21 @@
 }
 
 .ag-theme-alpine-dark .ag-header-cell-resize::after {
-  background-color: #00ddff;
+  background-color: rgb(var(--accent-secondary));
 }
 
 .ag-theme-alpine-dark .ag-row {
-  background-color: #0a0e14;
-  border-bottom: 1px solid rgba(255, 180, 50, 0.04);
+  background-color: rgb(var(--surface-900));
+  border-bottom: 1px solid rgb(var(--accent-primary) / 0.04);
   transition: background-color 0.1s ease;
 }
 
 .ag-theme-alpine-dark .ag-row-odd {
-  background-color: #0e1319;
+  background-color: rgb(var(--surface-850));
 }
 
 .ag-theme-alpine-dark .ag-row:hover {
-  background-color: rgba(0, 221, 255, 0.06) !important;
+  background-color: rgb(var(--accent-secondary) / 0.06) !important;
 }
 
 .ag-theme-alpine-dark .ag-cell {
@@ -321,18 +461,21 @@
 }
 
 .ag-theme-alpine-dark .ag-body-viewport {
-  background-color: #0a0e14;
+  background-color: rgb(var(--surface-900));
 }
 
 .ag-theme-alpine-dark .ag-overlay-no-rows-wrapper {
-  background-color: #0a0e14;
+  background-color: rgb(var(--surface-900));
 }
 
 .ag-theme-alpine-dark .ag-overlay-no-rows-center {
-  color: #5a7090;
+  color: rgb(var(--surface-300));
 }
 
-/* Header Plugin — dockable instrument bar */
+/* ============================================================
+   HEADER PLUGIN — themed
+   ============================================================ */
+
 .header-plugin {
   display: flex;
   align-items: center;
@@ -343,7 +486,7 @@
   height: 100%;
   width: 100%;
   min-height: 0;
-  background: #0a0e14;
+  background: rgb(var(--surface-900));
   font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
   overflow: hidden;
   box-sizing: border-box;
@@ -361,7 +504,7 @@
 .header-plugin__sep {
   width: 1px;
   height: 32px;
-  background: rgba(255, 180, 50, 0.15);
+  background: rgb(var(--accent-primary) / 0.15);
   align-self: center;
   flex-shrink: 0;
 }
@@ -371,15 +514,15 @@
   font-weight: 900;
   font-size: 28px;
   letter-spacing: 2px;
-  color: #ffb432;
-  text-shadow: 0 0 12px rgba(255, 180, 50, 0.3);
+  color: rgb(var(--accent-primary));
+  text-shadow: var(--text-glow-primary);
   line-height: 1;
 }
 
 .header-plugin__version {
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
-  color: #5a7090;
+  color: rgb(var(--surface-300));
   align-self: flex-end;
   margin-bottom: 2px;
 }
@@ -390,23 +533,23 @@
   font-weight: 600;
   letter-spacing: 1.5px;
   text-transform: uppercase;
-  color: #00ff88;
+  color: rgb(var(--accent-success));
 }
 
 .header-plugin__time {
   font-family: 'Orbitron', system-ui, sans-serif;
   font-size: 28px;
   font-weight: 700;
-  color: #ffb432;
+  color: rgb(var(--accent-primary));
   letter-spacing: 2px;
   line-height: 1;
-  text-shadow: 0 0 10px rgba(255, 180, 50, 0.2);
+  text-shadow: var(--text-glow-secondary);
 }
 
 .header-plugin__date {
   font-family: 'JetBrains Mono', monospace;
   font-size: 13px;
-  color: #5a7090;
+  color: rgb(var(--surface-300));
   align-self: flex-end;
   margin-bottom: 2px;
 }
@@ -420,7 +563,7 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: 16px;
   font-weight: 600;
-  color: #00ddff;
+  color: rgb(var(--accent-secondary));
 }
 
 .header-plugin__indices {
@@ -431,15 +574,18 @@
   font-family: 'Orbitron', system-ui, sans-serif;
   font-size: 16px;
   font-weight: 700;
-  color: #ffb432;
+  color: rgb(var(--accent-primary));
 }
 
 .header-plugin__value--danger {
-  color: #ff4466;
-  text-shadow: 0 0 8px rgba(255, 68, 102, 0.4);
+  color: rgb(var(--accent-danger));
+  text-shadow: var(--text-glow-primary);
 }
 
-/* Custom animations */
+/* ============================================================
+   ANIMATIONS
+   ============================================================ */
+
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
@@ -459,8 +605,8 @@
   animation: radio-wave 2s ease-out infinite;
 }
 
-/* CRT scanline effect — very subtle atmosphere */
-.crt-scanlines::after {
+/* CRT scanline effect — only in dark mode */
+.dark .crt-scanlines::after {
   content: '';
   position: absolute;
   inset: 0;

--- a/src/Log4YM.Web/tailwind.config.js
+++ b/src/Log4YM.Web/tailwind.config.js
@@ -13,48 +13,64 @@ export default {
         ui: ['Space Grotesk', 'system-ui', 'sans-serif'],
       },
       colors: {
-        // OpenHamClock instrument panel palette
-        glass: {
-          50: 'rgba(255, 180, 50, 0.04)',
-          100: 'rgba(255, 180, 50, 0.08)',
-          200: 'rgba(255, 180, 50, 0.12)',
-          300: 'rgba(255, 180, 50, 0.18)',
-        },
+        // Surface/background colors — themed via CSS custom properties
         dark: {
-          900: '#0a0e14',        // Deepest background
-          850: '#0e1319',        // Between 900 and 800
-          800: '#111820',        // Panel/sidebar background
-          700: '#1a2332',        // Elevated surface
-          600: '#243044',        // Borders, dividers
-          500: '#2e3d55',        // Lighter elements
-          400: '#3d5070',        // Muted interactive
-          300: '#5a7090',        // Muted text
-          200: '#8899aa',        // Secondary text
+          900: 'rgb(var(--surface-900) / <alpha-value>)',
+          850: 'rgb(var(--surface-850) / <alpha-value>)',
+          800: 'rgb(var(--surface-800) / <alpha-value>)',
+          700: 'rgb(var(--surface-700) / <alpha-value>)',
+          600: 'rgb(var(--surface-600) / <alpha-value>)',
+          500: 'rgb(var(--surface-500) / <alpha-value>)',
+          400: 'rgb(var(--surface-400) / <alpha-value>)',
+          300: 'rgb(var(--surface-300) / <alpha-value>)',
+          200: 'rgb(var(--surface-200) / <alpha-value>)',
         },
+        // Glass/overlay tints — derived from accent-primary
+        glass: {
+          50: 'rgb(var(--accent-primary) / 0.04)',
+          100: 'rgb(var(--accent-primary) / 0.08)',
+          200: 'rgb(var(--accent-primary) / 0.12)',
+          300: 'rgb(var(--accent-primary) / 0.18)',
+        },
+        // Accent colors — themed
         accent: {
-          primary: '#ffb432',    // Amber — signature accent
-          secondary: '#00ddff',  // Cyan — secondary accent
-          success: '#00ff88',    // Green — section headers, good status
-          warning: '#ffb432',    // Amber — warnings
-          danger: '#ff4466',     // Red — alerts, errors
-          info: '#00ddff',       // Cyan — informational
+          primary: 'rgb(var(--accent-primary) / <alpha-value>)',
+          secondary: 'rgb(var(--accent-secondary) / <alpha-value>)',
+          success: 'rgb(var(--accent-success) / <alpha-value>)',
+          warning: 'rgb(var(--accent-warning) / <alpha-value>)',
+          danger: 'rgb(var(--accent-danger) / <alpha-value>)',
+          info: 'rgb(var(--accent-info) / <alpha-value>)',
         },
+        // Ham radio mode colors — themed
         ham: {
-          cw: '#ffb432',         // Amber for CW
-          ssb: '#00ff88',        // Green for SSB
-          ft8: '#00ddff',        // Cyan for FT8
-          rtty: '#aa66ff',       // Purple for RTTY
-        }
+          cw: 'rgb(var(--ham-cw) / <alpha-value>)',
+          ssb: 'rgb(var(--ham-ssb) / <alpha-value>)',
+          ft8: 'rgb(var(--ham-ft8) / <alpha-value>)',
+          rtty: 'rgb(var(--ham-rtty) / <alpha-value>)',
+        },
+        // Gray scale — semantically inverted for light/dark themes
+        gray: {
+          50: 'rgb(var(--gray-50) / <alpha-value>)',
+          100: 'rgb(var(--gray-100) / <alpha-value>)',
+          200: 'rgb(var(--gray-200) / <alpha-value>)',
+          300: 'rgb(var(--gray-300) / <alpha-value>)',
+          400: 'rgb(var(--gray-400) / <alpha-value>)',
+          500: 'rgb(var(--gray-500) / <alpha-value>)',
+          600: 'rgb(var(--gray-600) / <alpha-value>)',
+          700: 'rgb(var(--gray-700) / <alpha-value>)',
+          800: 'rgb(var(--gray-800) / <alpha-value>)',
+          900: 'rgb(var(--gray-900) / <alpha-value>)',
+        },
       },
       backdropBlur: {
         xs: '2px',
       },
       boxShadow: {
-        'glass': '0 8px 32px 0 rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 180, 50, 0.05)',
-        'glass-sm': '0 4px 16px 0 rgba(0, 0, 0, 0.4)',
-        'glow': '0 0 20px rgba(255, 180, 50, 0.25)',
-        'glow-success': '0 0 20px rgba(0, 255, 136, 0.25)',
-        'glow-cyan': '0 0 20px rgba(0, 221, 255, 0.25)',
+        'glass': 'var(--shadow-glass)',
+        'glass-sm': 'var(--shadow-glass-sm)',
+        'glow': 'var(--shadow-glow)',
+        'glow-success': 'var(--shadow-glow-success)',
+        'glow-cyan': 'var(--shadow-glow-cyan)',
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
@@ -66,8 +82,8 @@ export default {
       },
       keyframes: {
         glow: {
-          '0%': { boxShadow: '0 0 5px rgba(255, 180, 50, 0.15)' },
-          '100%': { boxShadow: '0 0 20px rgba(255, 180, 50, 0.35)' },
+          '0%': { boxShadow: '0 0 5px rgb(var(--accent-primary) / 0.15)' },
+          '100%': { boxShadow: '0 0 20px rgb(var(--accent-primary) / 0.35)' },
         }
       }
     },

--- a/src/Log4YM.Web/vite.config.ts
+++ b/src/Log4YM.Web/vite.config.ts
@@ -11,16 +11,16 @@ export default defineConfig({
   plugins: [react(), ...(useHttps ? [basicSsl()] : [])],
   base: "./",
   server: {
-    port: 5173,
+    port: 5183,
     host: true,
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: "http://localhost:5050",
+        target: "http://localhost:5060",
         changeOrigin: true,
       },
       "/hubs": {
-        target: "http://localhost:5050",
+        target: "http://localhost:5060",
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
## Summary
- Converts all hardcoded colors to CSS custom properties with light/dark variants
- Light theme: clean white backgrounds, deep indigo/purple accents, soft shadows
- Dark theme: retains instrument panel aesthetic with amber/cyan accents
- System theme: follows OS `prefers-color-scheme` preference with live tracking
- New `useTheme` hook manages theme application and system preference detection
- Visual theme previews in Settings > Appearance panel
- Dev ports offset by 10 (Vite 5183, backend proxy 5060)

## Test plan
- [ ] Verify dark theme looks identical to before
- [ ] Verify light theme has clean white panels with indigo accents
- [ ] Verify system theme follows OS dark/light preference
- [ ] Verify switching themes in Settings > Appearance applies instantly
- [ ] Verify FlexLayout tabs, AG Grid, header bar all theme correctly
- [ ] Verify CRT scanlines only appear in dark mode
- [ ] Run `npm run build` — passes cleanly
- [ ] Run `npm run test` — all 114 tests pass

Closes #86