### PR TITLE
fix: wire DX cluster spot grid data through to map overlay

### DIFF
--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(lsof:*), Bash(kill:*), Bash(xargs:*), Bash(cd * && dotnet run*), Bash(cd * && npm run dev*), Bash(sleep:*)
+allowed-tools: Bash(lsof:*), Bash(kill:*), Bash(xargs:*), Bash(cd * && ASPNETCORE_URLS=* dotnet run*), Bash(cd * && BACKEND_PORT=* npm run dev*), Bash(cd * && npm run dev*), Bash(cd * && dotnet run*), Bash(sleep:*)
 description: Start the .NET backend and Vite frontend dev servers
 ---
 
@@ -22,7 +22,9 @@ lsof -ti :<backend_port> | xargs kill 2>/dev/null; lsof -ti :<frontend_port> | x
 Then start both servers in parallel as background bash tasks:
 
 1. .NET backend: `cd src/Log4YM.Server && ASPNETCORE_URLS=http://localhost:<backend_port> dotnet run`
-2. Vite frontend: `cd src/Log4YM.Web && npm run dev -- --port <frontend_port>`
+2. Vite frontend: `cd src/Log4YM.Web && BACKEND_PORT=<backend_port> npm run dev -- --port <frontend_port>`
+
+The `BACKEND_PORT` env var tells the Vite proxy which backend port to forward `/api` and `/hubs` requests to.
 
 Replace `<backend_port>` and `<frontend_port>` with the calculated values.
 

--- a/src/Log4YM.Contracts/Events/LogEvents.cs
+++ b/src/Log4YM.Contracts/Events/LogEvents.cs
@@ -69,7 +69,8 @@ public record SpotReceivedEvent(
     DateTime Timestamp,
     string Source,
     string? Country,
-    int? Dxcc
+    int? Dxcc,
+    string? Grid
 );
 
 /// <summary>

--- a/src/Log4YM.Server/Services/DxClusterService.cs
+++ b/src/Log4YM.Server/Services/DxClusterService.cs
@@ -277,7 +277,8 @@ public class DxClusterService : IDxClusterService, IHostedService, IDisposable
             parsedSpot.Timestamp,
             source,
             parsedSpot.Country,
-            parsedSpot.Dxcc
+            parsedSpot.Dxcc,
+            parsedSpot.Grid
         );
 
         await _hubContext.Clients.All.OnSpotReceived(evt);

--- a/src/Log4YM.Web/src/api/signalr.ts
+++ b/src/Log4YM.Web/src/api/signalr.ts
@@ -48,6 +48,7 @@ export interface SpotReceivedEvent {
   source: string;
   country?: string;
   dxcc?: number;
+  grid?: string;
 }
 
 export interface SpotSelectedEvent {

--- a/src/Log4YM.Web/src/hooks/useSignalR.ts
+++ b/src/Log4YM.Web/src/hooks/useSignalR.ts
@@ -126,9 +126,10 @@ export function useSignalRConnection() {
               source: evt.source,
               timestamp: evt.timestamp,
               country: evt.country,
-              dxStation: evt.country || evt.dxcc ? {
+              dxStation: (evt.country || evt.dxcc || evt.grid) ? {
                 country: evt.country,
                 dxcc: evt.dxcc,
+                grid: evt.grid,
               } : undefined,
             };
             useAppStore.getState().addDxClusterSpot(spot);

--- a/src/Log4YM.Web/src/plugins/MapPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/MapPlugin.tsx
@@ -2,8 +2,7 @@ import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { Map as MapIcon, MapPin, Target, Maximize2, ZoomIn, ZoomOut, Layers, Sun } from 'lucide-react';
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents, Circle, Polyline, Tooltip } from 'react-leaflet';
 import L from 'leaflet';
-import { useQuery } from '@tanstack/react-query';
-import { useAppStore } from '../store/appStore';
+import { useAppStore, Spot } from '../store/appStore';
 import { useSettingsStore } from '../store/settingsStore';
 import { useSignalR } from '../hooks/useSignalR';
 import { GlassPanel } from '../components/GlassPanel';
@@ -11,7 +10,6 @@ import { DXNewsTicker } from '../components/DXNewsTicker';
 import { DayNightOverlay } from '../components/DayNightOverlay';
 import { GrayLineOverlay } from '../components/GrayLineOverlay';
 import { gridToLatLon, calculateDistance, getAnimationDuration } from '../utils/maidenhead';
-import { api, Spot } from '../api/client';
 
 import 'leaflet/dist/leaflet.css';
 
@@ -278,13 +276,8 @@ export function MapPlugin() {
   const { settings, updateMapSettings, saveSettings } = useSettingsStore();
   const { commandRotator } = useSignalR();
 
-  // Fetch spots for map overlay
-  const { data: spots } = useQuery({
-    queryKey: ['spots'],
-    queryFn: () => api.getSpots({ limit: 100 }),
-    refetchInterval: 30000,
-    enabled: dxClusterMapEnabled,
-  });
+  // DX cluster spots from ephemeral in-memory store (populated via SignalR)
+  const spots = useAppStore((state) => state.dxClusterSpots);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [currentAzimuth, setCurrentAzimuth] = useState(0);
   const [showLayerPicker, setShowLayerPicker] = useState(false);

--- a/src/Log4YM.Web/vite.config.ts
+++ b/src/Log4YM.Web/vite.config.ts
@@ -6,6 +6,7 @@ import basicSsl from "@vitejs/plugin-basic-ssl";
 // Use HTTPS only when VITE_HTTPS=true (for remote access where WebGL requires secure context)
 // Usage: VITE_HTTPS=true npm run dev
 const useHttps = process.env.VITE_HTTPS === "true";
+const backendPort = process.env.BACKEND_PORT || "5050";
 
 export default defineConfig({
   plugins: [react(), ...(useHttps ? [basicSsl()] : [])],
@@ -16,11 +17,11 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       "/api": {
-        target: "http://localhost:5050",
+        target: `http://localhost:${backendPort}`,
         changeOrigin: true,
       },
       "/hubs": {
-        target: "http://localhost:5050",
+        target: `http://localhost:${backendPort}`,
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
## Summary

- **Fixed broken map overlay**: MapPlugin was querying a non-existent `/api/spots` HTTP endpoint. Now reads from `dxClusterSpots` in the app store (populated in real-time via SignalR)
- **Piped grid square through the stack**: `DxClusterService` already parsed grid from cluster data but never included it in `SpotReceivedEvent`. Now flows through backend → SignalR → frontend store → map
- **Made Vite proxy port configurable**: Added `BACKEND_PORT` env var to `vite.config.ts` so the `/run` skill correctly proxies API/hub requests when using port offsets

## Test plan

- [ ] Connect to a DX cluster and verify spots appear in the cluster panel
- [ ] Enable the map overlay (map icon button in cluster panel header)
- [ ] Verify great-circle paths appear on the map for spots that have grid data
- [ ] Hover over a spot in the cluster grid and verify the corresponding path highlights on the map
- [ ] Test `/run 20` skill and verify frontend correctly proxies to the offset backend port

🤖 Generated with [Claude Code](https://claude.com/claude-code)