### PR TITLE
feat(pota): add park map markers with coordinate enrichment

### DIFF
--- a/src/Log4YM.Server/Controllers/PotaController.cs
+++ b/src/Log4YM.Server/Controllers/PotaController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using System.Text.Json;
 
 namespace Log4YM.Server.Controllers;
@@ -10,15 +11,18 @@ public class PotaController : ControllerBase
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<PotaController> _logger;
+    private readonly IMemoryCache _cache;
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-    public PotaController(IHttpClientFactory httpClientFactory, ILogger<PotaController> logger)
+    public PotaController(IHttpClientFactory httpClientFactory, ILogger<PotaController> logger, IMemoryCache cache)
     {
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        _cache = cache;
     }
 
     /// <summary>
-    /// Get active POTA spots from POTA API
+    /// Get active POTA spots from POTA API, enriched with park coordinates
     /// </summary>
     [HttpGet("spots")]
     [ProducesResponseType(typeof(IEnumerable<PotaSpot>), StatusCodes.Status200OK)]
@@ -33,18 +37,97 @@ public class PotaController : ControllerBase
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();
-            var spots = JsonSerializer.Deserialize<List<PotaSpot>>(content, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
+            var spots = JsonSerializer.Deserialize<List<PotaSpot>>(content, JsonOptions)
+                ?? new List<PotaSpot>();
 
-            return Ok(spots ?? new List<PotaSpot>());
+            // Enrich spots with park coordinates from cache or park API
+            var uniqueRefs = spots
+                .Where(s => !string.IsNullOrEmpty(s.Reference) && s.Latitude is null)
+                .Select(s => s.Reference)
+                .Distinct()
+                .ToList();
+
+            var parkCoords = await GetParkCoordinates(httpClient, uniqueRefs);
+
+            foreach (var spot in spots)
+            {
+                if (spot.Latitude is null && parkCoords.TryGetValue(spot.Reference, out var coords))
+                {
+                    spot.Latitude = coords.Lat;
+                    spot.Longitude = coords.Lon;
+                }
+            }
+
+            return Ok(spots);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to fetch POTA spots");
             return Ok(new List<PotaSpot>());
         }
+    }
+
+    private async Task<Dictionary<string, (double Lat, double Lon)>> GetParkCoordinates(
+        HttpClient httpClient, List<string> references)
+    {
+        var result = new Dictionary<string, (double Lat, double Lon)>();
+        var toFetch = new List<string>();
+
+        // Check cache first
+        foreach (var reference in references)
+        {
+            var cacheKey = $"pota_park_{reference}";
+            if (_cache.TryGetValue(cacheKey, out (double Lat, double Lon) cached))
+            {
+                result[reference] = cached;
+            }
+            else
+            {
+                toFetch.Add(reference);
+            }
+        }
+
+        // Fetch missing park data in parallel (limited concurrency)
+        if (toFetch.Count > 0)
+        {
+            using var semaphore = new SemaphoreSlim(10);
+            var tasks = toFetch.Select(async reference =>
+            {
+                await semaphore.WaitAsync();
+                try
+                {
+                    var parkResponse = await httpClient.GetAsync($"https://api.pota.app/park/{reference}");
+                    if (parkResponse.IsSuccessStatusCode)
+                    {
+                        var parkJson = await parkResponse.Content.ReadAsStringAsync();
+                        var park = JsonSerializer.Deserialize<PotaPark>(parkJson, JsonOptions);
+                        if (park?.Latitude is not null && park.Longitude is not null)
+                        {
+                            var coords = (park.Latitude.Value, park.Longitude.Value);
+                            _cache.Set($"pota_park_{reference}", coords, TimeSpan.FromHours(24));
+                            return (reference, coords: ((double Lat, double Lon)?)coords);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to fetch park {Reference}", reference);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+                return (reference, coords: ((double Lat, double Lon)?)null);
+            });
+
+            foreach (var (reference, coords) in await Task.WhenAll(tasks))
+            {
+                if (coords.HasValue)
+                    result[reference] = coords.Value;
+            }
+        }
+
+        return result;
     }
 }
 
@@ -65,6 +148,12 @@ public class PotaSpot
     public string? LocationDesc { get; set; }
     public string? Grid4 { get; set; }
     public string? Grid6 { get; set; }
+    public double? Latitude { get; set; }
+    public double? Longitude { get; set; }
+}
+
+public class PotaPark
+{
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
 }

--- a/src/Log4YM.Server/Program.cs
+++ b/src/Log4YM.Server/Program.cs
@@ -22,6 +22,7 @@ builder.Host.UseSerilog();
 
 // Add controllers
 builder.Services.AddControllers();
+builder.Services.AddMemoryCache();
 
 // Add API Explorer and Swagger
 builder.Services.AddEndpointsApiExplorer();

--- a/src/Log4YM.Web/src/__tests__/store/appStore.test.ts
+++ b/src/Log4YM.Web/src/__tests__/store/appStore.test.ts
@@ -15,7 +15,6 @@ describe('appStore', () => {
       selectedSpot: null,
       clusterStatuses: {},
       potaSpots: [],
-      showPotaMapMarkers: false,
       dxClusterMapEnabled: false,
       hoveredSpotId: null,
     });
@@ -148,13 +147,6 @@ describe('appStore', () => {
       expect(useAppStore.getState().potaSpots).toHaveLength(1);
     });
 
-    it('toggles POTA map markers', () => {
-      useAppStore.getState().setShowPotaMapMarkers(true);
-      expect(useAppStore.getState().showPotaMapMarkers).toBe(true);
-
-      useAppStore.getState().setShowPotaMapMarkers(false);
-      expect(useAppStore.getState().showPotaMapMarkers).toBe(false);
-    });
   });
 
   describe('DX cluster map', () => {

--- a/src/Log4YM.Web/src/plugins/MapPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/MapPlugin.tsx
@@ -61,21 +61,19 @@ const targetIcon = new L.DivIcon({
   iconAnchor: [10, 10],
 });
 
-// Custom POTA marker (green triangle)
+// Custom POTA marker (pine tree)
 const potaIcon = new L.DivIcon({
   className: 'custom-pota-marker',
   html: `
-    <div style="
-      width: 0;
-      height: 0;
-      border-left: 8px solid transparent;
-      border-right: 8px solid transparent;
-      border-bottom: 14px solid #10b981;
-      filter: drop-shadow(0 0 4px rgba(16, 185, 129, 0.6));
-    "></div>
+    <div style="filter: drop-shadow(0 0 4px rgba(16, 185, 129, 0.5));">
+      <svg width="20" height="24" viewBox="0 0 20 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 1L3 10h3L2 16h5v6h6v-6h5l-4-6h3L10 1z" fill="#10b981" stroke="#065f46" stroke-width="0.75"/>
+        <rect x="8" y="16" width="4" height="6" fill="#7c5e3c" stroke="#5c4033" stroke-width="0.5"/>
+      </svg>
+    </div>
   `,
-  iconSize: [16, 14],
-  iconAnchor: [8, 14],
+  iconSize: [20, 24],
+  iconAnchor: [10, 24],
 });
 
 // Custom satellite marker (purple/magenta diamond)
@@ -291,7 +289,7 @@ export function MapPlugin() {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<L.Map | null>(null);
   const lastTargetCoordsRef = useRef<{ lat: number; lon: number } | null>(null);
-  const { stationGrid, rotatorPosition, focusedCallsignInfo, potaSpots, showPotaMapMarkers, dxClusterMapEnabled, hoveredSpotId } = useAppStore();
+  const { stationGrid, rotatorPosition, focusedCallsignInfo, potaSpots, dxClusterMapEnabled, hoveredSpotId } = useAppStore();
   const { settings, updateMapSettings, saveSettings } = useSettingsStore();
   const { commandRotator } = useSignalR();
 
@@ -771,7 +769,7 @@ export function MapPlugin() {
           })}
 
           {/* POTA markers - show when enabled and we have spot data with coordinates */}
-          {showPotaMapMarkers && potaSpots.map((spot) => {
+          {settings.map.showPotaOverlay && potaSpots.map((spot) => {
             if (!spot.latitude || !spot.longitude) return null;
             return (
               <Marker
@@ -784,6 +782,12 @@ export function MapPlugin() {
                     <strong className="text-accent-success font-mono">{spot.activator}</strong>
                     <br />
                     <span className="text-xs font-mono text-accent-info">{spot.reference}</span>
+                    {spot.parkName && (
+                      <>
+                        <br />
+                        <span className="text-xs text-gray-300">{spot.parkName}</span>
+                      </>
+                    )}
                     <br />
                     <span className="text-xs text-gray-400">
                       {(parseFloat(spot.frequency) / 1000).toFixed(3)} MHz • {spot.mode}

--- a/src/Log4YM.Web/src/plugins/POTAPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/POTAPlugin.tsx
@@ -9,6 +9,7 @@ import { api, PotaSpot } from '../api/client';
 import { useSignalR } from '../hooks/useSignalR';
 import { GlassPanel } from '../components/GlassPanel';
 import { useAppStore } from '../store/appStore';
+import { useSettingsStore } from '../store/settingsStore';
 
 const formatTime = (dateStr: string) => {
   if (!dateStr) return '--:--';
@@ -67,7 +68,8 @@ const TimeCellRenderer = (props: ICellRendererParams<PotaSpot>) => {
 
 export function POTAPlugin() {
   const { selectSpot } = useSignalR();
-  const { showPotaMapMarkers, setShowPotaMapMarkers, setPotaSpots } = useAppStore();
+  const { setPotaSpots } = useAppStore();
+  const { settings, updateMapSettings, saveSettings } = useSettingsStore();
 
   const { data: spots, isLoading } = useQuery({
     queryKey: ['pota-spots'],
@@ -189,9 +191,12 @@ export function POTAPlugin() {
             {filteredSpots?.length || 0} active
           </span>
           <button
-            onClick={() => setShowPotaMapMarkers(!showPotaMapMarkers)}
-            className={`glass-button p-1.5 ${showPotaMapMarkers ? 'text-accent-success' : 'text-gray-500'}`}
-            title={showPotaMapMarkers ? 'Hide map markers' : 'Show map markers'}
+            onClick={() => {
+              updateMapSettings({ showPotaOverlay: !settings.map.showPotaOverlay });
+              saveSettings();
+            }}
+            className={`glass-button p-1.5 ${settings.map.showPotaOverlay ? 'text-accent-info' : 'text-dark-300'}`}
+            title={settings.map.showPotaOverlay ? 'Hide map overlay' : 'Show map overlay'}
           >
             <Map className="w-4 h-4" />
           </button>

--- a/src/Log4YM.Web/src/store/appStore.ts
+++ b/src/Log4YM.Web/src/store/appStore.ts
@@ -114,11 +114,9 @@ interface AppState {
   clusterStatuses: Record<string, ClusterStatus>;
   setClusterStatus: (clusterId: string, status: ClusterStatus) => void;
 
-  // POTA spots and map markers
+  // POTA spots
   potaSpots: PotaSpot[];
-  showPotaMapMarkers: boolean;
   setPotaSpots: (spots: PotaSpot[]) => void;
-  setShowPotaMapMarkers: (show: boolean) => void;
 
   // DX Cluster map overlay
   dxClusterMapEnabled: boolean;
@@ -388,11 +386,9 @@ export const useAppStore = create<AppState>((set) => ({
       },
     })),
 
-  // POTA spots and map markers
+  // POTA spots
   potaSpots: [],
-  showPotaMapMarkers: false,
   setPotaSpots: (spots) => set({ potaSpots: spots }),
-  setShowPotaMapMarkers: (show) => set({ showPotaMapMarkers: show }),
 
   // DX Cluster map overlay
   dxClusterMapEnabled: false,

--- a/src/Log4YM.Web/src/store/settingsStore.ts
+++ b/src/Log4YM.Web/src/store/settingsStore.ts
@@ -69,6 +69,7 @@ export interface MapSettings {
   showSatellites: boolean;
   selectedSatellites: string[];
   rbn: RbnSettings;
+  showPotaOverlay: boolean;
   showDayNightOverlay: boolean;
   showGrayLine: boolean;
   showSunMarker: boolean;
@@ -219,6 +220,7 @@ const defaultSettings: Settings = {
       bands: ['all'],
       modes: ['CW', 'RTTY'],
     },
+    showPotaOverlay: false,
     showDayNightOverlay: false,
     showGrayLine: false,
     showSunMarker: true,


### PR DESCRIPTION
## Summary
- Enrich POTA spots with park GPS coordinates by looking up each unique park reference via the POTA park API (`api.pota.app/park/{ref}`), with 24-hour in-memory caching and parallel fetches (concurrency limit of 10)
- Replace the green triangle map marker with a pine tree SVG icon and show park name in the popup
- Move POTA overlay toggle to persisted settings store so it survives page refreshes, using the same Map icon and styling as the DX cluster toggle

## Test plan
- [ ] Open POTA widget, click the map toggle button — tree markers should appear on the map for active activations
- [ ] Toggle off — markers disappear
- [ ] Refresh the page — toggle state persists
- [ ] Hover/click a tree marker — popup shows callsign, park reference, park name, frequency, mode, location

🤖 Generated with [Claude Code](https://claude.com/claude-code)