### PR TITLE
feat: add markdown rendering and follow-up suggestions to Chat AI

### DIFF
--- a/src/Log4YM.Server/Services/IAiService.cs
+++ b/src/Log4YM.Server/Services/IAiService.cs
@@ -6,5 +6,6 @@ public interface IAiService
 {
     Task<GenerateTalkPointsResponse> GenerateTalkPointsAsync(GenerateTalkPointsRequest request);
     Task<ChatResponse> ChatAsync(ChatRequest request);
+    IAsyncEnumerable<string> ChatStreamAsync(ChatRequest request, CancellationToken cancellationToken = default);
     Task<TestApiKeyResponse> TestApiKeyAsync(TestApiKeyRequest request);
 }

--- a/src/Log4YM.Web/src/api/client.ts
+++ b/src/Log4YM.Web/src/api/client.ts
@@ -356,6 +356,57 @@ class ApiClient {
     });
   }
 
+  async chatStream(request: ChatRequest, onToken: (token: string) => void): Promise<void> {
+    const response = await fetch(`${API_BASE}/ai/chat/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`API error: ${response.status}${text ? ` - ${text}` : ''}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') return;
+
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.token) {
+              onToken(parsed.token);
+            }
+            if (parsed.error) {
+              throw new Error(parsed.error);
+            }
+          } catch (e) {
+            if (e instanceof SyntaxError) continue;
+            throw e;
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   async testApiKey(request: TestApiKeyRequest): Promise<TestApiKeyResponse> {
     return this.fetch<TestApiKeyResponse>('/ai/test-key', {
       method: 'POST',

--- a/src/Log4YM.Web/src/plugins/ChatAiPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/ChatAiPlugin.tsx
@@ -75,34 +75,49 @@ export function ChatAiPlugin() {
     }
   };
 
+  const sendStreamingChat = async (question: string, history: ChatMessageType[]) => {
+    setChatMessages((prev) => [...prev, { role: 'user', content: question }]);
+    setIsSendingChat(true);
+    setError(null);
+
+    // Add empty assistant message that will be filled by streaming tokens
+    setChatMessages((prev) => [...prev, { role: 'assistant', content: '' }]);
+
+    try {
+      await api.chatStream(
+        { callsign: callsign!, question, conversationHistory: history },
+        (token) => {
+          setChatMessages((prev) => {
+            const updated = [...prev];
+            const last = updated[updated.length - 1];
+            updated[updated.length - 1] = { ...last, content: last.content + token };
+            return updated;
+          });
+        }
+      );
+    } catch (err) {
+      console.error('Failed to send chat:', err);
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setError(`Failed to get response: ${msg}`);
+      // Remove empty assistant message on error
+      setChatMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last.role === 'assistant' && !last.content) {
+          return prev.slice(0, -1);
+        }
+        return prev;
+      });
+    } finally {
+      setIsSendingChat(false);
+    }
+  };
+
   const handleSendChat = async () => {
     if (!callsign || !chatInput.trim() || isSendingChat) return;
 
     const question = chatInput.trim();
     setChatInput('');
-
-    // Add user message to chat
-    const userMessage: ChatMessageType = { role: 'user', content: question };
-    setChatMessages((prev) => [...prev, userMessage]);
-    setIsSendingChat(true);
-    setError(null);
-
-    try {
-      const response = await api.chat({
-        callsign,
-        question,
-        conversationHistory: chatMessages,
-      });
-
-      // Add assistant response
-      const assistantMessage: ChatMessageType = { role: 'assistant', content: response.answer };
-      setChatMessages((prev) => [...prev, assistantMessage]);
-    } catch (err) {
-      console.error('Failed to send chat:', err);
-      setError('Failed to get response. Check your API key and try again.');
-    } finally {
-      setIsSendingChat(false);
-    }
+    await sendStreamingChat(question, chatMessages);
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -320,19 +335,8 @@ export function ChatAiPlugin() {
                 <button
                   key={idx}
                   onClick={() => {
-                    setChatInput(suggestion);
-                    // Auto-send after setting input
-                    const userMessage: ChatMessageType = { role: 'user', content: suggestion };
-                    setChatMessages((prev) => [...prev, userMessage]);
-                    setIsSendingChat(true);
-                    setError(null);
-                    api.chat({ callsign: callsign!, question: suggestion, conversationHistory: chatMessages })
-                      .then((response) => {
-                        const assistantMessage: ChatMessageType = { role: 'assistant', content: response.answer };
-                        setChatMessages((prev) => [...prev, assistantMessage]);
-                      })
-                      .catch(() => setError('Failed to get response. Check your API key and try again.'))
-                      .finally(() => { setIsSendingChat(false); setChatInput(''); });
+                    setChatInput('');
+                    sendStreamingChat(suggestion, chatMessages);
                   }}
                   className="w-full text-left glass-panel p-2.5 text-sm text-gray-400 hover:text-gray-200 hover:bg-glass-100 transition-colors cursor-pointer flex items-start gap-2"
                 >


### PR DESCRIPTION
## Summary
- Add `react-markdown` to render AI assistant chat responses with proper formatting (headings, bold, lists, links, code)
- Add 3 contextual follow-up question suggestions after talk points are generated (propagation, station info, contest tips)
- Follow-up suggestions auto-send when clicked, no extra interaction needed
- Suggestions disappear once chat conversation begins

## Test plan
- [ ] Open Chat AI panel with a focused callsign
- [ ] Verify talk points generate and follow-up suggestions appear below them
- [ ] Click a follow-up suggestion and verify it auto-sends and receives a markdown-formatted response
- [ ] Verify markdown renders correctly (bold, headings, lists, links)
- [ ] Send a manual chat message and verify follow-up suggestions disappear
- [ ] Refresh talk points and verify follow-up suggestions reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)