### PR TITLE
Fix app hang on fresh install after uninstall

### DIFF
--- a/src/Log4YM.Desktop/main.js
+++ b/src/Log4YM.Desktop/main.js
@@ -109,6 +109,8 @@ async function startBackend() {
     return;
   }
 
+  const backendDir = path.dirname(backendPath);
+
   // Make executable on Unix and remove macOS quarantine attribute
   if (process.platform !== 'win32') {
     try {
@@ -130,8 +132,6 @@ async function startBackend() {
       log.warn(`Could not remove quarantine attribute: ${err.message}`);
     }
   }
-
-  const backendDir = path.dirname(backendPath);
   backendProcess = spawn(backendPath, [], {
     cwd: backendDir,
     env: {


### PR DESCRIPTION
## Summary
- After uninstalling and reinstalling on macOS, the app hung at "Loading Data..." for ~2 minutes because `~/Library/Application Support/Log4YM/config.json` persists with `Provider=MongoDb` and the MongoDB driver tried to connect to a stale/unreachable Atlas cluster
- Falls back to Local (LiteDB) provider when config has MongoDb but no connection string
- Adds hard 10s CancellationToken timeout to MongoDB ping to cap SRV/DNS hangs
- Adds 15s frontend rehydration timeout so the UI never hangs indefinitely
- Fixes `backendDir` used before declaration in Electron `main.js` (xattr quarantine removal was silently failing)

## Test plan
- [ ] Delete `~/Library/Application Support/Log4YM/config.json`, install DMG, verify app starts with LiteDB immediately
- [ ] Create a `config.json` with `{"Provider":"MongoDb"}` (no connection string), verify app falls back to Local within seconds
- [ ] Create a `config.json` with a stale Atlas connection string, verify app starts within ~15 seconds max
- [ ] Verify normal MongoDB Atlas flow still works when cluster is reachable
- [ ] Verify hot-reload dev workflow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)