### PR TITLE
Fix fresh install defaulting to MongoDB

### DIFF
--- a/src/Log4YM.Server/Core/Database/MongoDbContext.cs
+++ b/src/Log4YM.Server/Core/Database/MongoDbContext.cs
@@ -121,7 +121,9 @@ public class MongoDbContext : IDbContext
 
     private string? GetConnectionString()
     {
-        // Priority: 1) User config file, 2) appsettings.json
+        // Use the connection string from config.json (or env var via IConfiguration fallback).
+        // The appsettings.json default was removed to prevent fresh desktop installs
+        // from accidentally defaulting to MongoDB.
         var config = _userConfigService.GetConfigAsync().GetAwaiter().GetResult();
         if (!string.IsNullOrEmpty(config.MongoDbConnectionString))
         {

--- a/src/Log4YM.Server/appsettings.json
+++ b/src/Log4YM.Server/appsettings.json
@@ -14,10 +14,6 @@
       }
     }
   },
-  "MongoDB": {
-    "ConnectionString": "mongodb://localhost:27017",
-    "DatabaseName": "Log4YM"
-  },
   "DxCluster": {
     "Host": "de.ve7cc.net",
     "Port": 23,


### PR DESCRIPTION
## Summary
- Removed the default MongoDB section from `appsettings.json` (`mongodb://localhost:27017`) that caused fresh desktop installs to falsely default to MongoDB instead of Local/LiteDB
- Docker deployments must now set `MongoDB__ConnectionString` env var explicitly (no behavior change for Docker since it already does this)
- Added test `Fresh_Install_No_Config_No_EnvVar_Defaults_To_Local` verifying the fix
- Updated `MongoDbContext.GetConnectionString()` comment explaining the removal

## Context
Discovered during local Electron "first run" testing: even with no `config.json` and no env var, `builder.Configuration["MongoDB:ConnectionString"]` returned `mongodb://localhost:27017` from `appsettings.json`, triggering the MongoDB path in `Program.cs`. This is the final piece of the fresh-install hang fix chain (PRs #127, #128, #130).

## Test plan
- [x] All 277 unit tests pass
- [x] Local Electron first-run test: backend starts in ~2s with Local provider, settings save/load works, UI loads instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)