### PR TITLE
Fix day/night overlay vertical artifact at antimeridian

### DIFF
--- a/src/Log4YM.Web/src/components/DayNightOverlay.tsx
+++ b/src/Log4YM.Web/src/components/DayNightOverlay.tsx
@@ -11,7 +11,8 @@ interface DayNightOverlayProps {
 
 /**
  * Day/Night overlay using Leaflet vector polygon, matching OpenHamClock's terminator style.
- * Renders the night side as a polygon with a dashed orange/amber border and subtle dark fill.
+ * Renders the night side as a filled polygon with transparent stroke (to avoid antimeridian
+ * artifact), and the terminator line as a separate dashed polyline.
  */
 export function DayNightOverlay({
   opacity = 0.7,
@@ -51,9 +52,22 @@ export function DayNightOverlay({
           polygonPoints.push([nightPole, lastLon]);
           polygonPoints.push([nightPole, firstLon]);
 
+          // Polygon with transparent stroke to avoid antimeridian closing-edge artifact
           L.polygon(polygonPoints, {
             fillColor: '#000020',
             fillOpacity: 0.35 * opacity,
+            color: 'transparent',
+            weight: 0,
+            interactive: false,
+          }).addTo(layerGroup);
+        }
+
+        // Draw the terminator line separately as a polyline (no closing edge issue)
+        for (const offset of [-360, 0, 360]) {
+          const linePoints: L.LatLngExpression[] = termLine.map(
+            ([lat, lon]) => [lat, lon + offset]
+          );
+          L.polyline(linePoints, {
             color: '#ffaa00',
             weight: 2,
             dashArray: '5, 5',

--- a/src/Log4YM.Web/src/utils/geoUtils.ts
+++ b/src/Log4YM.Web/src/utils/geoUtils.ts
@@ -1,0 +1,17 @@
+/**
+ * Unwrap longitudes so no consecutive pair jumps more than 180°.
+ * This prevents Leaflet from drawing lines/edges across the entire map
+ * when a polygon or polyline crosses the antimeridian (±180° boundary).
+ *
+ * Based on the approach from OpenHamClock's gray line plugin.
+ */
+export function unwrapLongitudes(points: [number, number][]): [number, number][] {
+  if (points.length < 2) return points.map(p => [p[0], p[1]]);
+
+  const unwrapped: [number, number][] = points.map(p => [p[0], p[1]]);
+  for (let i = 1; i < unwrapped.length; i++) {
+    while (unwrapped[i][1] - unwrapped[i - 1][1] > 180) unwrapped[i][1] -= 360;
+    while (unwrapped[i][1] - unwrapped[i - 1][1] < -180) unwrapped[i][1] += 360;
+  }
+  return unwrapped;
+}


### PR DESCRIPTION
## Summary
- Fixed the vertical dashed line artifact in the day/night overlay caused by the polygon's closing edge jumping 360° of longitude across the antimeridian
- Separated the night polygon fill (transparent stroke) from the terminator line (separate polyline), matching OpenHamClock's approach
- Added `unwrapLongitudes()` utility for GrayLineOverlay polygons and polylines as a defensive measure

## Test plan
- [x] Verified with Playwright: day/night overlay renders cleanly with no vertical artifact
- [ ] Check terminator line renders correctly at various zoom levels
- [ ] Verify gray line overlay has no antimeridian artifacts when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)