### PR TITLE
fix: Hamlib mode switching - map SSB to LSB/USB based on frequency

### DIFF
--- a/src/Log4YM.Server/Hubs/LogHub.cs
+++ b/src/Log4YM.Server/Hubs/LogHub.cs
@@ -354,7 +354,7 @@ public class LogHub : Hub<ILogHubClient>
                 // Also set mode if provided
                 if (!string.IsNullOrEmpty(evt.Mode))
                 {
-                    var modeSet = await _hamlibService.SetModeAsync(evt.Mode);
+                    var modeSet = await _hamlibService.SetModeAsync(evt.Mode, frequencyHz);
                     if (modeSet)
                     {
                         _logger.LogInformation("Set Hamlib radio mode to {Mode}", evt.Mode);


### PR DESCRIPTION
Fixes #168

**Root Cause:** Hamlib does not understand generic "SSB" mode strings - it only knows "LSB" and "USB". When clicking an SSB DX cluster spot, "SSB" was passed directly to rig_parse_mode() which returned RIG_MODE_NONE, causing the mode switch to fail silently (radio stayed in CW).

Adds MapToHamlibMode() (mirroring TCI's MapToTciMode()) that converts:
- "SSB" → "LSB" (< 10 MHz) or "USB" (≥ 10 MHz) based on frequency
- "CWU" → "CW", "CWL" → "CWR"
- Digital modes (FT8, FT4, JT65, etc.) → "PKTUSB"
- "FMN" → "FM"

Generated with [Claude Code](https://claude.ai/code)