### PR TITLE
feat(qrz): add QRZ.com buttons and improve profile layout

### DIFF
--- a/src/Log4YM.Web/src/plugins/LogEntryPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/LogEntryPlugin.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Send, Search, User, MapPin, Radio, Link, Unlink, Clock, Lock, LockOpen, Loader2, X, ChevronDown } from 'lucide-react';
+import { Send, Search, User, MapPin, Radio, Link, Unlink, Clock, Lock, LockOpen, Loader2, X, ChevronDown, ExternalLink } from 'lucide-react';
 import { api, CreateQsoRequest } from '../api/client';
 import { useSignalR } from '../hooks/useSignalR';
 import { useAppStore } from '../store/appStore';
@@ -488,6 +488,14 @@ export function LogEntryPlugin() {
               <div className="text-3xl" title={focusedCallsignInfo.country || 'Unknown country'}>
                 {getCountryFlag(focusedCallsignInfo.country, '')}
               </div>
+              <button
+                type="button"
+                onClick={() => window.open(`https://www.qrz.com/db/${focusedCallsignInfo.callsign}`, '_blank', 'noopener,noreferrer')}
+                className="p-1.5 rounded transition-colors text-accent-primary hover:bg-dark-600"
+                title="QRZ.com"
+              >
+                <ExternalLink className="w-4 h-4" />
+              </button>
             </div>
           </div>
         )}

--- a/src/Log4YM.Web/src/plugins/MapPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/MapPlugin.tsx
@@ -862,6 +862,15 @@ export function MapPlugin() {
                         </span>
                       </>
                     )}
+                    <br />
+                    <a
+                      href={`https://www.qrz.com/db/${focusedCallsignInfo?.callsign}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: '#ffb432', fontSize: '11px', textDecoration: 'none' }}
+                    >
+                      QRZ.com ↗
+                    </a>
                   </div>
                 </Popup>
               </Marker>
@@ -882,6 +891,15 @@ export function MapPlugin() {
                         </span>
                       </>
                     )}
+                    <br />
+                    <a
+                      href={`https://www.qrz.com/db/${focusedCallsignInfo?.callsign}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: '#ffb432', fontSize: '11px', textDecoration: 'none' }}
+                    >
+                      QRZ.com ↗
+                    </a>
                   </div>
                 </Popup>
               </Marker>
@@ -907,6 +925,15 @@ export function MapPlugin() {
                   {img.grid && (
                     <><br /><span className="text-xs font-mono" style={{ color: '#8899aa' }}>{img.grid}</span></>
                   )}
+                  <br />
+                  <a
+                    href={`https://www.qrz.com/db/${img.callsign}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: '#00ddff', fontSize: '11px', textDecoration: 'none' }}
+                  >
+                    QRZ.com ↗
+                  </a>
                 </div>
               </Popup>
             </Marker>

--- a/src/Log4YM.Web/src/plugins/QrzProfilePlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/QrzProfilePlugin.tsx
@@ -50,14 +50,14 @@ export function QrzProfilePlugin() {
 
         {/* Profile content */}
         {!isLookingUpCallsign && focusedCallsignInfo && (
-          <div className="flex-1 flex flex-col">
-            {/* Profile image */}
-            <div className="flex justify-center mb-4">
+          <div className="flex-1 flex flex-col min-h-0">
+            {/* Profile image - takes remaining space */}
+            <div className="flex-1 flex justify-center items-center mb-4 min-h-0 overflow-hidden">
               {focusedCallsignInfo.imageUrl ? (
                 <img
                   src={focusedCallsignInfo.imageUrl}
                   alt={focusedCallsignInfo.callsign}
-                  className="w-32 h-32 rounded-xl object-cover border-2 border-glass-100 shadow-lg"
+                  className="max-w-full max-h-full rounded-xl object-contain border-2 border-glass-100 shadow-lg"
                 />
               ) : (
                 <div className="w-32 h-32 rounded-xl bg-dark-700 border-2 border-glass-100 flex items-center justify-center">
@@ -66,6 +66,8 @@ export function QrzProfilePlugin() {
               )}
             </div>
 
+            {/* Bottom section - always visible */}
+            <div className="flex-shrink-0">
             {/* Callsign and name */}
             <div className="text-center mb-4">
               <div className="flex items-center justify-center gap-3 mb-2">
@@ -150,8 +152,9 @@ export function QrzProfilePlugin() {
                 className="mt-4 w-full glass-button py-2 flex items-center justify-center gap-2 text-accent-primary hover:bg-dark-600 transition-colors font-ui"
               >
                 <ExternalLink className="w-4 h-4" />
-                <span className="text-sm font-medium">View Full QRZ Profile</span>
+                <span className="text-sm font-medium">QRZ.com</span>
               </button>
+            </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Add QRZ.com external link button to the log entry callsign info card (next to country flag)
- Add QRZ.com links to map popups for focused and saved callsign markers
- Rename "View Full QRZ Profile" to consistent "QRZ.com" label across the app
- Improve QRZ profile widget layout: image flexes to fill available space while bottom section (callsign info, location details, button) stays pinned and always visible without scrolling

## Test plan
- [ ] Verify QRZ.com button appears on log entry callsign info card and opens correct QRZ page
- [ ] Verify QRZ.com links appear in map popups for both focused and saved callsign markers
- [ ] Verify QRZ profile widget image scales to fill available space
- [ ] Verify QRZ profile bottom section (callsign, location, button) is always visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)