### PR TITLE
fix(spectrum): round DPR-scaled dimensions to fix waterfall

### DIFF
--- a/src/Log4YM.Web/src/plugins/PanadapterPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/PanadapterPlugin.tsx
@@ -60,8 +60,8 @@ export function PanadapterPlugin() {
     if (!ctx) return;
 
     const dpr = window.devicePixelRatio || 1;
-    const w = canvas.width / dpr;
-    const h = canvas.height / dpr;
+    const w = Math.round(canvas.width / dpr);
+    const h = Math.round(canvas.height / dpr);
     if (w === 0 || h === 0) {
       // Tab is hidden (FlexLayout display:none) — keep the loop alive
       rafIdRef.current = requestAnimationFrame(render);


### PR DESCRIPTION
## Summary
- Rounds `canvas.width / dpr` and `canvas.height / dpr` to integers using `Math.round()` to prevent the waterfall buffer from being recreated every frame
- Non-integer CSS pixel dimensions caused the off-screen waterfall buffer canvas to truncate its width/height, failing the size equality check each frame and destroying accumulated waterfall data

## Test plan
- [ ] Open the Panadapter panel with N1MM+ spectrum data active
- [ ] Verify the waterfall scrolls and accumulates colored rows over time
- [ ] Test on displays with non-integer DPR (e.g., 1.5x scaling) to confirm buffer stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)