### PR TITLE
fix(spots): build status cache in background to unblock startup

### DIFF
--- a/src/Log4YM.Server.Tests/Tests/Services/SpotStatusServiceTests.cs
+++ b/src/Log4YM.Server.Tests/Tests/Services/SpotStatusServiceTests.cs
@@ -68,6 +68,7 @@ public class SpotStatusServiceTests
     public async Task GetSpotStatus_NeverWorkedCountry_ReturnsNewDxcc()
     {
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, "SSB")
             .Should().Be("newDxcc");
@@ -81,6 +82,7 @@ public class SpotStatusServiceTests
             MakeQso("DL1ABC", country: "Germany", band: "20m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // United States was never worked, only Germany
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, "SSB")
@@ -99,6 +101,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: "United States", band: "40m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Same country but on 20m instead of 40m
         _service.GetSpotStatus("W2XYZ", "United States", 14000.0, "SSB")
@@ -117,6 +120,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: "United States", band: "20m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Same country+band+mode — "worked" regardless of specific callsign
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, "SSB")
@@ -131,6 +135,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: "United States", band: "20m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Different callsign but same country+band+mode → still "worked"
         _service.GetSpotStatus("W9XYZ", "United States", 14000.0, "SSB")
@@ -145,6 +150,7 @@ public class SpotStatusServiceTests
             MakeQso("w1abc", country: "united states", band: "20m", mode: "ssb"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, "SSB")
             .Should().Be("worked");
@@ -167,6 +173,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: "United States", band: "20m", mode: loggedMode),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, spotMode)
             .Should().Be("worked");
@@ -184,6 +191,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: "United States", band: "20m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Same country+band but no mode in spot — can't determine worked status, returns null
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, null)
@@ -198,6 +206,7 @@ public class SpotStatusServiceTests
     public async Task OnQsoLogged_UpdatesCache_NewDxccBecomesWorked()
     {
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, "SSB")
             .Should().Be("newDxcc");
@@ -216,6 +225,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: "United States", band: "40m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W2XYZ", "United States", 14000.0, "SSB")
             .Should().Be("newBand");
@@ -234,6 +244,7 @@ public class SpotStatusServiceTests
     public async Task InvalidateCacheAsync_RebuildsCacheFromDatabase()
     {
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W1ABC", "United States", 14000.0, "SSB")
             .Should().Be("newDxcc");
@@ -265,6 +276,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: qsoCountry, band: "20m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Spot uses alias name, QSO uses ADIF name — should still match
         _service.GetSpotStatus("W1ABC", spotCountry, 14000.0, "SSB")
@@ -281,6 +293,7 @@ public class SpotStatusServiceTests
             MakeQso("G4ABC", country: "England", band: "40m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("M7JTV", "England", 14000.0, "CW")
             .Should().Be("worked");
@@ -294,6 +307,7 @@ public class SpotStatusServiceTests
     public async Task OnQsoLogged_SameEntityName_MatchesSpotLookup()
     {
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Log a QSO with ADIF entity name
         _service.OnQsoLogged("G4ABC", "England", "20m", "SSB");
@@ -313,6 +327,7 @@ public class SpotStatusServiceTests
             MakeQso("DL1ABC", country: "Germany", band: "20m", mode: "SSB"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Spot arrives with cty.dat name "Fed. Rep. of Germany" — should NOT be newDxcc
         _service.GetSpotStatus("DL2RH", "Fed. Rep. of Germany", 14000.0, "SSB")
@@ -323,6 +338,7 @@ public class SpotStatusServiceTests
     public async Task OnQsoLogged_CtyDatNameMismatch_AlsoIndexesCtyName()
     {
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         // Log a QSO with common name "Germany" for a DL callsign
         _service.OnQsoLogged("DL1ABC", "Germany", "20m", "CW");
@@ -348,6 +364,7 @@ public class SpotStatusServiceTests
             MakeQso("W1ABC", country: country, band: expectedBand, mode: "CW"),
         });
         await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
 
         _service.GetSpotStatus("W1ABC", country, freqKhz, "CW")
             .Should().Be("worked");

--- a/src/Log4YM.Server/Core/Database/MongoDbContext.cs
+++ b/src/Log4YM.Server/Core/Database/MongoDbContext.cs
@@ -59,13 +59,14 @@ public class MongoDbContext : IDbContext
 
                 Log.Information("MongoDB connecting to database: {DatabaseName}", databaseName);
 
-                // Configure client with aggressive timeouts to prevent blocking on startup.
-                // SRV DNS lookups for unreachable Atlas clusters can hang for minutes
-                // if we rely solely on the driver's built-in timeouts.
+                // Aggressive *connection* timeouts prevent blocking on startup when
+                // SRV DNS lookups for unreachable Atlas clusters hang for minutes.
+                // SocketTimeout is left at the driver default — it applies to every
+                // read/write on an established connection, and a small value kills
+                // legitimate bulk queries (e.g. fetching all QSOs for the DXCC cache).
                 var settings = MongoClientSettings.FromConnectionString(connectionString);
                 settings.ConnectTimeout = TimeSpan.FromSeconds(5);
                 settings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
-                settings.SocketTimeout = TimeSpan.FromSeconds(5);
 
                 _client = new MongoClient(settings);
                 _database = _client.GetDatabase(databaseName);

--- a/src/Log4YM.Server/Services/SpotStatusService.cs
+++ b/src/Log4YM.Server/Services/SpotStatusService.cs
@@ -28,15 +28,59 @@ public class SpotStatusService : ISpotStatusService, IHostedService
         _logger = logger;
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    // Await this to know the initial cache build has finished (used by tests).
+    internal Task CacheReady => _cacheReady.Task;
+    private readonly TaskCompletionSource _cacheReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenSource _cacheRetryCts = new();
+
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("SpotStatusService starting, building cache...");
-        await BuildCacheAsync();
+        _logger.LogInformation("SpotStatusService starting, building cache in background...");
+
+        // Build the cache in the background so a slow MongoDB query
+        // (e.g. 4000+ QSOs over an Atlas link) never blocks app startup.
+        _ = Task.Run(async () =>
+        {
+            if (!await BuildCacheAsync())
+            {
+                await RetryBuildCacheAsync(_cacheRetryCts.Token);
+            }
+            _cacheReady.TrySetResult();
+        });
+
+        return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        _cacheRetryCts.Cancel();
+        _cacheReady.TrySetResult();
         return Task.CompletedTask;
+    }
+
+    private async Task RetryBuildCacheAsync(CancellationToken ct)
+    {
+        var delaySeconds = 5;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(delaySeconds), ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            _logger.LogInformation("SpotStatusService retrying cache build...");
+            if (await BuildCacheAsync())
+            {
+                _logger.LogInformation("SpotStatusService cache build succeeded on retry");
+                return;
+            }
+
+            delaySeconds = Math.Min(delaySeconds * 2, 60);
+        }
     }
 
     public string? GetSpotStatus(string dxCall, string? country, double frequencyKhz, string? mode)
@@ -117,7 +161,7 @@ public class SpotStatusService : ISpotStatusService, IHostedService
         await BuildCacheAsync();
     }
 
-    private async Task BuildCacheAsync()
+    private async Task<bool> BuildCacheAsync()
     {
         try
         {
@@ -177,10 +221,13 @@ public class SpotStatusService : ISpotStatusService, IHostedService
             _logger.LogInformation(
                 "SpotStatusService cache built: {CountryCount} countries, {BandCount} country+band combos, {ModeCount} country+band+mode entries",
                 newCountries.Count, newCountryBands.Count, newCountryBandModes.Count);
+
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to build SpotStatusService cache");
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- Move `SpotStatusService` cache build off the startup path into a background task with exponential-backoff retry, so a slow or unreachable MongoDB can't block app launch
- Drop the 5s `SocketTimeout` on `MongoClient` — it was killing legitimate bulk queries (e.g. loading thousands of QSOs for the DXCC cache). `ConnectTimeout` and `ServerSelectionTimeout` still guard against SRV DNS hangs on unreachable Atlas clusters
- Expose an internal `CacheReady` task so unit tests can deterministically wait for the initial cache build

## Test plan
- [ ] `dotnet test src/Log4YM.Server.Tests --filter "Category=Unit"` passes
- [ ] App starts immediately even when Mongo is slow or unreachable
- [ ] DXCC cache bulk QSO load completes without socket timeout