### PR TITLE
fix(spots): return null status until initial cache build completes

### DIFF
--- a/src/Log4YM.Server.Tests/Tests/Services/SpotStatusServiceTests.cs
+++ b/src/Log4YM.Server.Tests/Tests/Services/SpotStatusServiceTests.cs
@@ -32,18 +32,38 @@ public class SpotStatusServiceTests
         return services.BuildServiceProvider();
     }
 
+    #region GetSpotStatus — cache-not-ready guard
+
+    [Fact]
+    public void GetSpotStatus_BeforeCacheBuilt_ReturnsNull()
+    {
+        // StartAsync not yet called — the initial background cache build hasn't run,
+        // so every country would erroneously look "unworked". The guard must return
+        // null so spots arriving during startup don't get stamped with a wrong status.
+        _service.GetSpotStatus("YU7DX", "Serbia", 3700.0, "SSB")
+            .Should().BeNull();
+    }
+
+    #endregion
+
     #region GetSpotStatus — null country
 
     [Fact]
-    public void GetSpotStatus_NullCountry_ReturnsNull()
+    public async Task GetSpotStatus_NullCountry_ReturnsNull()
     {
+        await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
+
         _service.GetSpotStatus("W1ABC", null, 14000.0, "SSB")
             .Should().BeNull();
     }
 
     [Fact]
-    public void GetSpotStatus_EmptyCountry_ReturnsNull()
+    public async Task GetSpotStatus_EmptyCountry_ReturnsNull()
     {
+        await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
+
         _service.GetSpotStatus("W1ABC", "", 14000.0, "SSB")
             .Should().BeNull();
     }
@@ -53,8 +73,11 @@ public class SpotStatusServiceTests
     #region GetSpotStatus — Unknown band
 
     [Fact]
-    public void GetSpotStatus_UnknownBand_ReturnsNull()
+    public async Task GetSpotStatus_UnknownBand_ReturnsNull()
     {
+        await _service.StartAsync(CancellationToken.None);
+        await _service.CacheReady;
+
         // 500 kHz is not an amateur band
         _service.GetSpotStatus("W1ABC", "United States", 500.0, "SSB")
             .Should().BeNull();

--- a/src/Log4YM.Server/Services/SpotStatusService.cs
+++ b/src/Log4YM.Server/Services/SpotStatusService.cs
@@ -85,6 +85,13 @@ public class SpotStatusService : ISpotStatusService, IHostedService
 
     public string? GetSpotStatus(string dxCall, string? country, double frequencyKhz, string? mode)
     {
+        // Until the initial cache build completes, _workedCountries is empty and every
+        // lookup would return "newDxcc" — which then sticks on the spot in the UI even
+        // after the cache is ready. Return null (no status) during that window so spots
+        // arriving early show no indicator rather than a wrong one.
+        if (!_cacheReady.Task.IsCompleted)
+            return null;
+
         if (string.IsNullOrEmpty(country))
             return null;
 


### PR DESCRIPTION
## Summary
- Fix regression from #221 where spots arriving during the ~60s background cache build got stamped `newDxcc` and stayed red even after the cache finished building
- `GetSpotStatus` now returns `null` (no status dot) until the initial cache build completes — spots that arrive early show no indicator instead of a wrong one
- Add regression test `GetSpotStatus_BeforeCacheBuilt_ReturnsNull` and update existing guard-clause tests to call `StartAsync` / await `CacheReady` so they exercise the post-ready path

## Test plan
- [x] `dotnet test src/Log4YM.Server.Tests --filter "Category=Unit"` — 450/450 pass
- [ ] Start backend against a slow DB, verify spots arriving during cache build show no dot (not red)
- [ ] After cache build completes, new spots get correct `worked`/`newBand`/`newDxcc` statuses