### PR TITLE
feat(lotw): add LOTW upload via local TQSL subprocess

### DIFF
--- a/src/Log4YM.Contracts/Api/LotwDto.cs
+++ b/src/Log4YM.Contracts/Api/LotwDto.cs
@@ -1,0 +1,40 @@
+namespace Log4YM.Contracts.Api;
+
+public record LotwUploadFilter(
+    DateTime? DateFrom = null,
+    DateTime? DateTo = null,
+    string? StationCallsign = null,
+    IEnumerable<string>? Bands = null,
+    IEnumerable<string>? Modes = null,
+    // Adds lotw_qsl_sent='I' (Ignored) to the eligible set. Default: skipped.
+    bool IncludeIgnored = false,
+    // Adds lotw_qsl_sent='N' (explicit No) to the eligible set. Default: skipped.
+    bool IncludeNotSent = false
+    // Always eligible: null (never sent), 'R' (re-send requested), 'Q' (queued).
+);
+
+public record LotwUploadResult(
+    int QsoCount,
+    bool Success,
+    int TqslExitCode,
+    string Message,
+    int MarkedAsSent
+);
+
+public record LotwPreviewResponse(
+    int Count,
+    IEnumerable<LotwPreviewItem> Sample
+);
+
+public record LotwPreviewItem(
+    string Id,
+    string Callsign,
+    DateTime QsoDate,
+    string Band,
+    string Mode,
+    string? LotwSent
+);
+
+public record LotwTestTqslRequest(string Path);
+
+public record LotwTestTqslResponse(bool Ok, string? Version, string? Error);

--- a/src/Log4YM.Contracts/Events/LogEvents.cs
+++ b/src/Log4YM.Contracts/Events/LogEvents.cs
@@ -781,6 +781,21 @@ public record AdifImportProgressEvent(
     string? Message
 );
 
+// ===== LOTW Upload Events =====
+
+/// <summary>
+/// LOTW upload progress update. Stages: "preparing", "signing", "uploading", "done", "error".
+/// TQSL runs as an opaque subprocess, so per-QSO progress is not available — the event
+/// reports coarse phase transitions plus totals and the TQSL exit code on completion.
+/// </summary>
+public record LotwUploadProgressEvent(
+    string Stage,
+    int QsoCount,
+    bool IsComplete,
+    int? TqslExitCode,
+    string? Message
+);
+
 // ===== Tuner Genius Events =====
 
 /// <summary>

--- a/src/Log4YM.Contracts/Models/Qso.cs
+++ b/src/Log4YM.Contracts/Models/Qso.cs
@@ -99,6 +99,14 @@ public class Qso
     [BsonElement("qrzSyncStatus")]
     [BsonRepresentation(BsonType.String)]
     public SyncStatus QrzSyncStatus { get; set; } = SyncStatus.NotSynced;
+
+    // LOTW sync tracking
+    [BsonElement("lotwSyncedAt")]
+    public DateTime? LotwSyncedAt { get; set; }
+
+    [BsonElement("lotwSyncStatus")]
+    [BsonRepresentation(BsonType.String)]
+    public SyncStatus LotwSyncStatus { get; set; } = SyncStatus.NotSynced;
 }
 
 public class StationInfo
@@ -166,8 +174,14 @@ public class LotwStatus
     [BsonElement("sent")]
     public string? Sent { get; set; }
 
+    [BsonElement("sentDate")]
+    public DateTime? SentDate { get; set; }
+
     [BsonElement("rcvd")]
     public string? Rcvd { get; set; }
+
+    [BsonElement("rcvdDate")]
+    public DateTime? RcvdDate { get; set; }
 }
 
 public class EqslStatus

--- a/src/Log4YM.Contracts/Models/Settings.cs
+++ b/src/Log4YM.Contracts/Models/Settings.cs
@@ -15,6 +15,9 @@ public class UserSettings
     [BsonElement("qrz")]
     public QrzSettings Qrz { get; set; } = new();
 
+    [BsonElement("lotw")]
+    public LotwSettings Lotw { get; set; } = new();
+
     [BsonElement("appearance")]
     public AppearanceSettings Appearance { get; set; } = new();
 
@@ -97,6 +100,25 @@ public class QrzSettings
 
     [BsonElement("subscriptionCheckedAt")]
     public DateTime? SubscriptionCheckedAt { get; set; }
+}
+
+[BsonIgnoreExtraElements]
+public class LotwSettings
+{
+    // Absolute path to the local TQSL binary (e.g. C:\Program Files\TrustedQSL\tqsl.exe).
+    // Entered manually in Settings; no auto-detection in v1.
+    [BsonElement("tqslPath")]
+    public string? TqslPath { get; set; } = string.Empty;
+
+    // Optional TQSL station location name passed via `-l`. Null = TQSL default.
+    [BsonElement("stationCallsign")]
+    public string? StationCallsign { get; set; } = string.Empty;
+
+    [BsonElement("enabled")]
+    public bool Enabled { get; set; }
+
+    [BsonElement("lastUploadAt")]
+    public DateTime? LastUploadAt { get; set; }
 }
 
 [BsonIgnoreExtraElements]

--- a/src/Log4YM.Desktop/main.js
+++ b/src/Log4YM.Desktop/main.js
@@ -482,6 +482,20 @@ app.whenReady().then(async () => {
     }
   });
 
+  // Native file picker. Accepts { title?, defaultPath?, filters? } and returns
+  // the chosen absolute path (string) or null if the user cancelled.
+  ipcMain.handle('select-file', async (_event, options = {}) => {
+    if (!mainWindow) return null;
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: options.title || 'Select File',
+      defaultPath: options.defaultPath,
+      filters: options.filters,
+      properties: ['openFile']
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
+
   try {
     createSplashWindow();
     await startBackend();

--- a/src/Log4YM.Desktop/preload.js
+++ b/src/Log4YM.Desktop/preload.js
@@ -21,5 +21,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   restartApp: () => ipcRenderer.invoke('restart-app'),
   // Zoom level management
   getZoomLevel: () => ipcRenderer.invoke('get-zoom-level'),
-  setZoomLevel: (level) => ipcRenderer.invoke('set-zoom-level', level)
+  setZoomLevel: (level) => ipcRenderer.invoke('set-zoom-level', level),
+  // Native file picker — returns the selected absolute path, or null if cancelled.
+  // Used by the LOTW settings section to locate the TQSL binary.
+  selectFile: (options) => ipcRenderer.invoke('select-file', options)
 });

--- a/src/Log4YM.Server.Tests/Tests/Services/AdifServiceTests.cs
+++ b/src/Log4YM.Server.Tests/Tests/Services/AdifServiceTests.cs
@@ -296,7 +296,8 @@ public class AdifServiceTests
         var adif = _service.ExportToAdif(new[] { qso });
 
         adif.Should().Contain("<CALL:4>W1AW");
-        adif.Should().Contain("<BAND:3>20m");
+        // BAND is uppercased on export — LOTW silently drops "20m".
+        adif.Should().Contain("<BAND:3>20M");
         adif.Should().Contain("<MODE:3>SSB");
         adif.Should().Contain("<QSO_DATE:8>20240115");
         adif.Should().Contain("<EOR>");
@@ -410,7 +411,8 @@ public class AdifServiceTests
 
         reExported.Should().Contain("<CALL:4>W1AW");
         reExported.Should().Contain("<QSO_DATE:8>20240115");
-        reExported.Should().Contain("<BAND:3>20m");
+        // Export uppercases BAND even when the source ADIF had lowercase — LOTW is strict.
+        reExported.Should().Contain("<BAND:3>20M");
         reExported.Should().Contain("<MODE:3>SSB");
         reExported.Should().Contain("<RST_SENT:2>59");
         reExported.Should().Contain("<RST_RCVD:2>57");

--- a/src/Log4YM.Server/Controllers/LotwController.cs
+++ b/src/Log4YM.Server/Controllers/LotwController.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Mvc;
+using Log4YM.Contracts.Api;
+using Log4YM.Contracts.Models;
+using Log4YM.Server.Core.Database;
+using Log4YM.Server.Services;
+
+namespace Log4YM.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Produces("application/json")]
+public class LotwController : ControllerBase
+{
+    private readonly ILotwService _lotwService;
+    private readonly ISettingsRepository _settingsRepository;
+    private readonly ILogger<LotwController> _logger;
+
+    public LotwController(
+        ILotwService lotwService,
+        ISettingsRepository settingsRepository,
+        ILogger<LotwController> logger)
+    {
+        _lotwService = lotwService;
+        _settingsRepository = settingsRepository;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Preview which QSOs match the filter, without uploading.
+    /// </summary>
+    [HttpPost("preview")]
+    [ProducesResponseType(typeof(LotwPreviewResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<LotwPreviewResponse>> Preview([FromBody] LotwUploadFilter filter)
+    {
+        var result = await _lotwService.PreviewAsync(filter);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Export matching QSOs to ADIF, hand to TQSL for signing and upload, and mark sent on success.
+    /// </summary>
+    [HttpPost("upload")]
+    [ProducesResponseType(typeof(LotwUploadResult), StatusCodes.Status200OK)]
+    public async Task<ActionResult<LotwUploadResult>> Upload([FromBody] LotwUploadFilter filter, CancellationToken cancellationToken)
+    {
+        var result = await _lotwService.UploadAsync(filter, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Verify a TQSL binary by running `--version`. Used by the Settings panel's Test button.
+    /// </summary>
+    [HttpPost("test-tqsl")]
+    [ProducesResponseType(typeof(LotwTestTqslResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<LotwTestTqslResponse>> TestTqsl([FromBody] LotwTestTqslRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _lotwService.TestTqslAsync(request.Path, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Persist LOTW settings (TQSL path, station location, enabled).
+    /// </summary>
+    [HttpPut("settings")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateSettings([FromBody] LotwSettings request)
+    {
+        var settings = await _settingsRepository.GetAsync() ?? new UserSettings();
+        settings.Lotw.TqslPath = request.TqslPath;
+        settings.Lotw.StationCallsign = request.StationCallsign;
+        settings.Lotw.Enabled = request.Enabled;
+
+        await _settingsRepository.UpsertAsync(settings);
+
+        return Ok(new { message = "LOTW settings saved" });
+    }
+}

--- a/src/Log4YM.Server/Hubs/LogHub.cs
+++ b/src/Log4YM.Server/Hubs/LogHub.cs
@@ -64,6 +64,9 @@ public interface ILogHubClient
     // ADIF Import events
     Task OnAdifImportProgress(AdifImportProgressEvent evt);
 
+    // LOTW upload events
+    Task OnLotwUploadProgress(LotwUploadProgressEvent evt);
+
     // DX Cluster events
     Task OnClusterStatusChanged(ClusterStatusChangedEvent evt);
 
@@ -1098,6 +1101,11 @@ public static class LogHubExtensions
     public static async Task BroadcastAdifImportProgress(this IHubContext<LogHub, ILogHubClient> hub, AdifImportProgressEvent evt)
     {
         await hub.Clients.All.OnAdifImportProgress(evt);
+    }
+
+    public static async Task BroadcastLotwUploadProgress(this IHubContext<LogHub, ILogHubClient> hub, LotwUploadProgressEvent evt)
+    {
+        await hub.Clients.All.OnLotwUploadProgress(evt);
     }
 
     public static async Task BroadcastClusterStatusChanged(this IHubContext<LogHub, ILogHubClient> hub, ClusterStatusChangedEvent evt)

--- a/src/Log4YM.Server/Program.cs
+++ b/src/Log4YM.Server/Program.cs
@@ -128,6 +128,8 @@ builder.Services.AddScoped<IQsoService, QsoService>();
 builder.Services.AddScoped<IAwardsService, AwardsService>();
 builder.Services.AddScoped<ISettingsService, SettingsService>();
 builder.Services.AddScoped<IQrzService, QrzService>();
+builder.Services.AddSingleton<ITqslRunner, TqslRunner>();
+builder.Services.AddScoped<ILotwService, LotwService>();
 builder.Services.AddScoped<IAdifService, AdifService>();
 builder.Services.AddScoped<IAiService, AiService>();
 

--- a/src/Log4YM.Server/Services/AdifService.cs
+++ b/src/Log4YM.Server/Services/AdifService.cs
@@ -483,12 +483,22 @@ public partial class AdifService : IAdifService
 
     private void ExportQsoRecord(StringBuilder sb, Qso qso, string? stationCallsign)
     {
-        // Required fields
-        AppendAdifField(sb, "CALL", qso.Callsign);
-        AppendAdifField(sb, "QSO_DATE", qso.QsoDate.ToString("yyyyMMdd"));
-        AppendAdifField(sb, "TIME_ON", FormatTime(qso.TimeOn));
-        AppendAdifField(sb, "BAND", qso.Band);
-        AppendAdifField(sb, "MODE", qso.Mode);
+        // Required fields. BAND and MODE must be uppercase — LOTW's ingestion silently drops
+        // QSOs with lowercase band values like "20m" even though the ADIF spec says enums are
+        // case-insensitive. Every mainstream logger writes uppercase here.
+        //
+        // QSO_DATE and TIME_ON must be in UTC and must agree. We derive both from the same
+        // ToUniversalTime() DateTime so they can't drift. Previously we output QSO_DATE via
+        // qso.QsoDate.ToString(...) which, if LiteDB round-tripped the DateTime as Kind=Local,
+        // would produce the local date (e.g. Apr 17 in Ireland BST) while TIME_ON was the UTC
+        // time (23:52 Apr 16). The mismatch looked to LOTW like a QSO in the future, so it
+        // silently dropped the record during ingestion.
+        var qsoUtc = qso.QsoDate.ToUniversalTime();
+        AppendAdifField(sb, "CALL", qso.Callsign?.ToUpperInvariant());
+        AppendAdifField(sb, "QSO_DATE", qsoUtc.ToString("yyyyMMdd"));
+        AppendAdifField(sb, "TIME_ON", qsoUtc.ToString("HHmmss"));
+        AppendAdifField(sb, "BAND", qso.Band?.ToUpperInvariant());
+        AppendAdifField(sb, "MODE", qso.Mode?.ToUpperInvariant());
 
         // Optional standard fields
         if (!string.IsNullOrEmpty(qso.TimeOff))
@@ -657,8 +667,14 @@ public partial class AdifService : IAdifService
 
     private static string FormatTime(string? time)
     {
+        // ADIF TIME_ON / TIME_OFF is HHMM or HHMMSS, UTC, zero-padded on the LEFT.
+        // A raw "945" means 09:45, not 94:50 — PadRight was wrong and would push LOTW to
+        // silently drop the QSO on ingestion (invalid time component).
         if (string.IsNullOrEmpty(time)) return "0000";
-        return time.Replace(":", "").PadRight(4, '0')[..4];
+        var digits = time.Replace(":", "");
+        if (digits.Length <= 4) return digits.PadLeft(4, '0');
+        if (digits.Length <= 6) return digits.PadLeft(6, '0');
+        return digits[..6];
     }
 
     private static string DeriveFromFrequency(Dictionary<string, object> fields)

--- a/src/Log4YM.Server/Services/ILotwService.cs
+++ b/src/Log4YM.Server/Services/ILotwService.cs
@@ -1,0 +1,12 @@
+using Log4YM.Contracts.Api;
+
+namespace Log4YM.Server.Services;
+
+public interface ILotwService
+{
+    Task<LotwUploadResult> UploadAsync(LotwUploadFilter filter, CancellationToken cancellationToken);
+
+    Task<LotwPreviewResponse> PreviewAsync(LotwUploadFilter filter);
+
+    Task<LotwTestTqslResponse> TestTqslAsync(string path, CancellationToken cancellationToken);
+}

--- a/src/Log4YM.Server/Services/ITqslRunner.cs
+++ b/src/Log4YM.Server/Services/ITqslRunner.cs
@@ -1,0 +1,23 @@
+namespace Log4YM.Server.Services;
+
+/// <summary>
+/// Thin seam around the TQSL binary. Production impl uses System.Diagnostics.Process;
+/// unit tests inject a fake so LotwService logic can be exercised without a real TQSL install.
+/// </summary>
+public interface ITqslRunner
+{
+    /// <summary>
+    /// Run `tqsl -d -q -u &lt;adifPath&gt;` — sign and upload the given ADIF file to LOTW.
+    /// Returns TQSL's exit code (see http://www.arrl.org/command-1 for the canonical list).
+    /// </summary>
+    Task<TqslRunResult> UploadAsync(string tqslPath, string adifPath, string? stationLocation, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Run `tqsl --version` and return the parsed version string, or null if the binary couldn't be launched.
+    /// </summary>
+    Task<TqslVersionResult> GetVersionAsync(string tqslPath, CancellationToken cancellationToken);
+}
+
+public record TqslRunResult(int ExitCode, string StdOut, string StdErr);
+
+public record TqslVersionResult(bool Ok, string? Version, string? Error);

--- a/src/Log4YM.Server/Services/LotwService.cs
+++ b/src/Log4YM.Server/Services/LotwService.cs
@@ -1,0 +1,332 @@
+using System.Security.Principal;
+using Microsoft.AspNetCore.SignalR;
+using Log4YM.Contracts.Api;
+using Log4YM.Contracts.Events;
+using Log4YM.Contracts.Models;
+using Log4YM.Server.Core.Database;
+using Log4YM.Server.Hubs;
+
+namespace Log4YM.Server.Services;
+
+public class LotwService : ILotwService
+{
+    private readonly ISettingsRepository _settingsRepository;
+    private readonly IQsoRepository _qsoRepository;
+    private readonly IAdifService _adifService;
+    private readonly ITqslRunner _tqsl;
+    private readonly IHubContext<LogHub, ILogHubClient> _hub;
+    private readonly ILogger<LotwService> _logger;
+
+    // Preview sample cap — UI shows first N entries in the confirm dialog.
+    private const int PreviewSampleSize = 50;
+
+    public LotwService(
+        ISettingsRepository settingsRepository,
+        IQsoRepository qsoRepository,
+        IAdifService adifService,
+        ITqslRunner tqsl,
+        IHubContext<LogHub, ILogHubClient> hub,
+        ILogger<LotwService> logger)
+    {
+        _settingsRepository = settingsRepository;
+        _qsoRepository = qsoRepository;
+        _adifService = adifService;
+        _tqsl = tqsl;
+        _hub = hub;
+        _logger = logger;
+    }
+
+    public async Task<LotwPreviewResponse> PreviewAsync(LotwUploadFilter filter)
+    {
+        var eligible = await GetEligibleQsosAsync(filter);
+        var sample = eligible
+            .Take(PreviewSampleSize)
+            .Select(q => new LotwPreviewItem(
+                q.Id,
+                q.Callsign,
+                q.QsoDate,
+                q.Band,
+                q.Mode,
+                q.Qsl?.Lotw?.Sent))
+            .ToList();
+
+        return new LotwPreviewResponse(eligible.Count, sample);
+    }
+
+    public async Task<LotwUploadResult> UploadAsync(LotwUploadFilter filter, CancellationToken cancellationToken)
+    {
+        var settings = await _settingsRepository.GetAsync() ?? new UserSettings();
+        var lotw = settings.Lotw;
+
+        if (IsRunningAsAdmin())
+        {
+            var msg = "Log4YM is running as Administrator — TQSL refuses elevated runs and would silently corrupt the upload (wrong cert store). Close Log4YM (and any elevated terminal) and relaunch as a standard user.";
+            await BroadcastAsync("error", 0, null, msg, true);
+            return new LotwUploadResult(0, false, -1, msg, 0);
+        }
+
+        var pathError = ValidateTqslPath(lotw.TqslPath);
+        if (pathError != null)
+        {
+            await BroadcastAsync("error", 0, null, pathError, true);
+            return new LotwUploadResult(0, false, -1, pathError, 0);
+        }
+
+        var eligible = await GetEligibleQsosAsync(filter);
+        if (eligible.Count == 0)
+        {
+            var msg = "No QSOs match the filter.";
+            await BroadcastAsync("done", 0, null, msg, true);
+            return new LotwUploadResult(0, false, -1, msg, 0);
+        }
+
+        await BroadcastAsync("preparing", eligible.Count, null, $"Exporting {eligible.Count} QSOs to ADIF", false);
+
+        var stationCallsign = !string.IsNullOrWhiteSpace(filter.StationCallsign)
+            ? filter.StationCallsign
+            : (!string.IsNullOrWhiteSpace(lotw.StationCallsign)
+                ? lotw.StationCallsign
+                : settings.Station?.Callsign);
+
+        var adif = _adifService.ExportToAdif(eligible, stationCallsign);
+
+        // Persist the uploaded ADIF under %APPDATA%\Log4YM\lotw-uploads\ (or equivalent on
+        // mac/linux) with a timestamp — previously we wrote to %TEMP% and deleted in finally,
+        // which made post-mortem diff against another logger's ADIF impossible. Retained
+        // files are small (a few KB per QSO) and give the user a clear forensic trail when
+        // LOTW silently drops an upload during ingestion.
+        var archiveDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "Log4YM", "lotw-uploads");
+        Directory.CreateDirectory(archiveDir);
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var tempPath = Path.Combine(archiveDir, $"lotw-upload-{timestamp}-{Guid.NewGuid():N}.adi");
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, adif, cancellationToken);
+
+            await BroadcastAsync("signing", eligible.Count, null, "Handing off to TQSL for signing and upload", false);
+
+            var tqslResult = await _tqsl.UploadAsync(lotw.TqslPath!, tempPath, lotw.StationCallsign, cancellationToken);
+
+            var (success, message) = InterpretExitCode(tqslResult.ExitCode, eligible.Count);
+
+            // Include TQSL's own output — lets the user see exactly what the binary reported
+            // (e.g. "5 QSOs uploaded to LoTW"). Distinguishes "TQSL signed & transmitted" from
+            // "LOTW server-side processed" — exit 0 only confirms the former; the latter happens
+            // asynchronously on ARRL's queue.
+            var tqslOutput = ExtractTqslSummary(tqslResult);
+            var fullMessage = string.IsNullOrWhiteSpace(tqslOutput)
+                ? message
+                : $"{message}\n\nTQSL output:\n{tqslOutput}";
+            fullMessage += $"\n\nADIF saved to: {tempPath}";
+
+            var markedAsSent = 0;
+            if (success)
+            {
+                markedAsSent = await MarkQsosAsSentAsync(eligible);
+                settings.Lotw.LastUploadAt = DateTime.UtcNow;
+                await _settingsRepository.UpsertAsync(settings);
+            }
+
+            await BroadcastAsync(success ? "done" : "error", eligible.Count, tqslResult.ExitCode, fullMessage, true);
+
+            return new LotwUploadResult(eligible.Count, success, tqslResult.ExitCode, fullMessage, markedAsSent);
+        }
+        catch (OperationCanceledException)
+        {
+            await BroadcastAsync("error", eligible.Count, null, "Upload cancelled", true);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "LOTW upload failed");
+            await BroadcastAsync("error", eligible.Count, null, ex.Message, true);
+            return new LotwUploadResult(eligible.Count, false, -1, ex.Message, 0);
+        }
+    }
+
+    public async Task<LotwTestTqslResponse> TestTqslAsync(string path, CancellationToken cancellationToken)
+    {
+        var pathError = ValidateTqslPath(path);
+        if (pathError != null)
+        {
+            return new LotwTestTqslResponse(false, null, pathError);
+        }
+
+        var result = await _tqsl.GetVersionAsync(path, cancellationToken);
+        return new LotwTestTqslResponse(result.Ok, result.Version, result.Error);
+    }
+
+    // ----- helpers --------------------------------------------------------
+
+    /// <summary>
+    /// Reject obviously-wrong TQSL paths before we spawn them. Catches two footguns:
+    /// empty / missing file, and paths that point at a non-TQSL binary (e.g. the user
+    /// browsed to Log4YM.exe by mistake — running *that* just launches a second Log4YM
+    /// instead of returning an error). Soft filename match: basename must contain "tqsl"
+    /// (case-insensitive). Users who've renamed the binary can still proceed via a
+    /// message, but the default footgun is eliminated.
+    /// </summary>
+    /// <summary>
+    /// Detect when the backend is running elevated on Windows. TQSL refuses admin runs —
+    /// without this preflight the user gets a modal dialog that `-q` is supposed to
+    /// suppress, and if they click through, signing happens against the Administrator
+    /// account's (empty) cert store so LOTW silently drops the upload on ingest.
+    /// </summary>
+    private static bool IsRunningAsAdmin()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string? ValidateTqslPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return "TQSL path is not configured. Open Settings → LOTW and pick the tqsl executable.";
+        }
+
+        if (!File.Exists(path))
+        {
+            return $"TQSL not found at '{path}'. Check Settings → LOTW.";
+        }
+
+        var baseName = Path.GetFileNameWithoutExtension(path) ?? string.Empty;
+        if (!baseName.Contains("tqsl", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"'{Path.GetFileName(path)}' does not look like the TQSL binary. In Settings → LOTW, browse for 'tqsl' (or 'tqsl.exe' on Windows).";
+        }
+
+        return null;
+    }
+
+    private async Task<List<Qso>> GetEligibleQsosAsync(LotwUploadFilter filter)
+    {
+        var searchRequest = new QsoSearchRequest(
+            FromDate: filter.DateFrom,
+            ToDate: filter.DateTo,
+            Limit: 100_000);
+        var (qsos, _) = await _qsoRepository.SearchAsync(searchRequest);
+
+        var bands = filter.Bands?.Where(b => !string.IsNullOrWhiteSpace(b))
+            .Select(b => b.ToUpperInvariant()).ToHashSet();
+        var modes = filter.Modes?.Where(m => !string.IsNullOrWhiteSpace(m))
+            .Select(m => m.ToUpperInvariant()).ToHashSet();
+
+        return qsos
+            .Where(q => bands == null || bands.Count == 0 || (q.Band != null && bands.Contains(q.Band.ToUpperInvariant())))
+            .Where(q => modes == null || modes.Count == 0 || (q.Mode != null && modes.Contains(q.Mode.ToUpperInvariant())))
+            .Where(q => IsEligibleForUpload(q, filter))
+            .ToList();
+    }
+
+    private static bool IsEligibleForUpload(Qso qso, LotwUploadFilter filter)
+    {
+        // Matches pblog's `WHERE upper(lotw_qsl_sent) IN (...) OR lotw_qsl_sent IS NULL`
+        // (LotwDialog.cpp:123). Always eligible: null/empty, 'R', 'Q'. Optional: 'I', 'N'.
+        var sent = qso.Qsl?.Lotw?.Sent?.Trim().ToUpperInvariant();
+        if (string.IsNullOrEmpty(sent)) return true;
+        return sent switch
+        {
+            "R" or "Q" => true,
+            "I" => filter.IncludeIgnored,
+            "N" => filter.IncludeNotSent,
+            _ => false // 'Y' and anything else — skip
+        };
+    }
+
+    private async Task<int> MarkQsosAsSentAsync(List<Qso> qsos)
+    {
+        var now = DateTime.UtcNow;
+        var updated = 0;
+
+        foreach (var qso in qsos)
+        {
+            qso.Qsl ??= new QslStatus();
+            qso.Qsl.Lotw ??= new LotwStatus();
+            qso.Qsl.Lotw.Sent = "Y";
+            qso.Qsl.Lotw.SentDate = now;
+            qso.LotwSyncedAt = now;
+            qso.LotwSyncStatus = SyncStatus.Synced;
+
+            if (await _qsoRepository.UpdateAsync(qso.Id, qso))
+            {
+                updated++;
+            }
+        }
+
+        return updated;
+    }
+
+    /// <summary>
+    /// Map TQSL exit code to (success, user-facing message). Codes sourced from
+    /// http://www.arrl.org/command-1 and pblog's Lotw.cpp:88-140.
+    /// Exit 9 ("some QSOs were duplicates") still counts as success — the non-dupe
+    /// QSOs were accepted, and the dupes were already at LOTW. pblog treated this
+    /// as pure error and skipped the DB update; that's the bug we're not inheriting.
+    /// </summary>
+    private static (bool Success, string Message) InterpretExitCode(int exitCode, int qsoCount)
+    {
+        return exitCode switch
+        {
+            // Exit 0 means TQSL signed the file AND LOTW's upload endpoint accepted it.
+            // The server-side ingestion into the user's logbook is queued and async —
+            // it's why an uploaded QSO may not appear in "Your QSOs" on the LOTW website
+            // for several minutes after exit 0.
+            0 => (true, $"{qsoCount} QSO(s) signed and handed to LOTW. QSOs typically appear in your LOTW logbook within a few minutes."),
+            1 => (false, "Upload cancelled by user"),
+            2 => (false, "Upload rejected by LoTW"),
+            3 => (false, "Unexpected response from TQSL server"),
+            4 => (false, "TQSL utility error"),
+            5 => (false, "TQSLlib error"),
+            6 => (false, "TQSL could not open the input file"),
+            7 => (false, "TQSL could not open the output file"),
+            8 => (false, "All QSOs were duplicates or out of date range"),
+            9 => (true, "Upload accepted; some QSOs were duplicates or out of date range"),
+            10 => (false, "TQSL command syntax error"),
+            11 => (false, "LoTW connection error (no network or LoTW unreachable)"),
+            _ => (false, $"Unexpected TQSL exit code {exitCode}")
+        };
+    }
+
+    private Task BroadcastAsync(string stage, int qsoCount, int? exitCode, string? message, bool isComplete)
+    {
+        return _hub.BroadcastLotwUploadProgress(new LotwUploadProgressEvent(
+            stage, qsoCount, isComplete, exitCode, message));
+    }
+
+    /// <summary>
+    /// Pull a compact summary out of TQSL's output — stdout first, then stderr. Strips blank
+    /// lines and trims noise. Returned as-is for display in the upload banner.
+    /// </summary>
+    private static string ExtractTqslSummary(TqslRunResult result)
+    {
+        var combined = string.IsNullOrWhiteSpace(result.StdOut)
+            ? result.StdErr
+            : result.StdOut;
+        if (string.IsNullOrWhiteSpace(combined)) return string.Empty;
+
+        var lines = combined
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0)
+            .ToList();
+
+        // Cap at last 10 lines — TQSL typically prints 1-4 lines, but guard against runaway.
+        if (lines.Count > 10)
+        {
+            lines = lines.GetRange(lines.Count - 10, 10);
+        }
+        return string.Join("\n", lines);
+    }
+}

--- a/src/Log4YM.Server/Services/LotwService.cs
+++ b/src/Log4YM.Server/Services/LotwService.cs
@@ -90,26 +90,27 @@ public class LotwService : ILotwService
 
         var adif = _adifService.ExportToAdif(eligible, stationCallsign);
 
-        // Persist the uploaded ADIF under %APPDATA%\Log4YM\lotw-uploads\ (or equivalent on
-        // mac/linux) with a timestamp — previously we wrote to %TEMP% and deleted in finally,
-        // which made post-mortem diff against another logger's ADIF impossible. Retained
-        // files are small (a few KB per QSO) and give the user a clear forensic trail when
-        // LOTW silently drops an upload during ingestion.
+        // Write the ADIF under %APPDATA%\Log4YM\lotw-uploads\ (or the equivalent on mac/linux).
+        // On success we delete it — the QSO is marked sent in the DB and TQSL's copy is enough.
+        // On failure we keep it so the user can diff against a known-good ADIF, rerun signing
+        // manually with `tqsl -d -u <file>`, etc.
         var archiveDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "Log4YM", "lotw-uploads");
         Directory.CreateDirectory(archiveDir);
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
-        var tempPath = Path.Combine(archiveDir, $"lotw-upload-{timestamp}-{Guid.NewGuid():N}.adi");
+        var adifPath = Path.Combine(archiveDir, $"lotw-upload-{timestamp}-{Guid.NewGuid():N}.adi");
+        var keepAdif = false;
         try
         {
-            await File.WriteAllTextAsync(tempPath, adif, cancellationToken);
+            await File.WriteAllTextAsync(adifPath, adif, cancellationToken);
 
             await BroadcastAsync("signing", eligible.Count, null, "Handing off to TQSL for signing and upload", false);
 
-            var tqslResult = await _tqsl.UploadAsync(lotw.TqslPath!, tempPath, lotw.StationCallsign, cancellationToken);
+            var tqslResult = await _tqsl.UploadAsync(lotw.TqslPath!, adifPath, lotw.StationCallsign, cancellationToken);
 
             var (success, message) = InterpretExitCode(tqslResult.ExitCode, eligible.Count);
+            keepAdif = !success;
 
             // Include TQSL's own output — lets the user see exactly what the binary reported
             // (e.g. "5 QSOs uploaded to LoTW"). Distinguishes "TQSL signed & transmitted" from
@@ -119,7 +120,10 @@ public class LotwService : ILotwService
             var fullMessage = string.IsNullOrWhiteSpace(tqslOutput)
                 ? message
                 : $"{message}\n\nTQSL output:\n{tqslOutput}";
-            fullMessage += $"\n\nADIF saved to: {tempPath}";
+            if (keepAdif)
+            {
+                fullMessage += $"\n\nADIF retained for inspection: {adifPath}";
+            }
 
             var markedAsSent = 0;
             if (success)
@@ -135,14 +139,24 @@ public class LotwService : ILotwService
         }
         catch (OperationCanceledException)
         {
+            keepAdif = true;
             await BroadcastAsync("error", eligible.Count, null, "Upload cancelled", true);
             throw;
         }
         catch (Exception ex)
         {
+            keepAdif = true;
             _logger.LogError(ex, "LOTW upload failed");
             await BroadcastAsync("error", eligible.Count, null, ex.Message, true);
             return new LotwUploadResult(eligible.Count, false, -1, ex.Message, 0);
+        }
+        finally
+        {
+            if (!keepAdif)
+            {
+                try { if (File.Exists(adifPath)) File.Delete(adifPath); }
+                catch (Exception ex) { _logger.LogWarning(ex, "Failed to delete ADIF {Path}", adifPath); }
+            }
         }
     }
 

--- a/src/Log4YM.Server/Services/TqslRunner.cs
+++ b/src/Log4YM.Server/Services/TqslRunner.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+
+namespace Log4YM.Server.Services;
+
+public class TqslRunner : ITqslRunner
+{
+    private readonly ILogger<TqslRunner> _logger;
+
+    public TqslRunner(ILogger<TqslRunner> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<TqslRunResult> UploadAsync(string tqslPath, string adifPath, string? stationLocation, CancellationToken cancellationToken)
+    {
+        // -d: don't prompt for duplicates (treat as already sent)
+        // -q: quit after upload (no GUI)
+        // -u: upload to LoTW
+        // -l <name>: use the named station location (optional)
+        var args = new List<string> { "-d", "-q" };
+        if (!string.IsNullOrWhiteSpace(stationLocation))
+        {
+            args.Add("-l");
+            args.Add(stationLocation);
+        }
+        args.Add("-u");
+        args.Add(adifPath);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = tqslPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        // Drain stdout/stderr concurrently so TQSL doesn't block on a full pipe
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try { if (!process.HasExited) process.Kill(entireProcessTree: true); } catch { }
+            throw;
+        }
+
+        var stdOut = await stdOutTask;
+        var stdErr = await stdErrTask;
+
+        _logger.LogInformation("TQSL exited with code {ExitCode}", process.ExitCode);
+        // Bumped to Info so operators can confirm TQSL's own view of the transaction
+        // (how many QSOs it extracted, how many uploaded) without toggling debug logging.
+        if (!string.IsNullOrWhiteSpace(stdOut)) _logger.LogInformation("TQSL stdout: {StdOut}", stdOut);
+        if (!string.IsNullOrWhiteSpace(stdErr)) _logger.LogInformation("TQSL stderr: {StdErr}", stdErr);
+
+        return new TqslRunResult(process.ExitCode, stdOut, stdErr);
+    }
+
+    public async Task<TqslVersionResult> GetVersionAsync(string tqslPath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(tqslPath))
+        {
+            return new TqslVersionResult(false, null, "TQSL path is empty");
+        }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = tqslPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("--version");
+
+        try
+        {
+            using var process = new Process { StartInfo = psi };
+            process.Start();
+
+            var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+            await process.WaitForExitAsync(cancellationToken);
+
+            var stdOut = (await stdOutTask).Trim();
+            var stdErr = (await stdErrTask).Trim();
+
+            // TQSL prints its version to stderr on some platforms, stdout on others.
+            var combined = !string.IsNullOrEmpty(stdOut) ? stdOut : stdErr;
+
+            if (process.ExitCode == 0 || !string.IsNullOrWhiteSpace(combined))
+            {
+                return new TqslVersionResult(true, combined.Length > 0 ? combined : null, null);
+            }
+
+            return new TqslVersionResult(false, null, $"TQSL exited with code {process.ExitCode}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to invoke TQSL at {Path}", tqslPath);
+            return new TqslVersionResult(false, null, ex.Message);
+        }
+    }
+}

--- a/src/Log4YM.Web/src/api/client.ts
+++ b/src/Log4YM.Web/src/api/client.ts
@@ -390,6 +390,27 @@ class ApiClient {
     });
   }
 
+  async uploadToLotw(filter: LotwUploadFilter = {}): Promise<LotwUploadResult> {
+    return this.fetch('/lotw/upload', {
+      method: 'POST',
+      body: JSON.stringify(filter),
+    });
+  }
+
+  async previewLotw(filter: LotwUploadFilter = {}): Promise<LotwPreviewResponse> {
+    return this.fetch('/lotw/preview', {
+      method: 'POST',
+      body: JSON.stringify(filter),
+    });
+  }
+
+  async testTqsl(path: string): Promise<LotwTestTqslResponse> {
+    return this.fetch('/lotw/test-tqsl', {
+      method: 'POST',
+      body: JSON.stringify({ path }),
+    });
+  }
+
   async lookupCallsignQrz(callsign: string): Promise<QrzCallsignResponse> {
     return this.fetch(`/qrz/lookup/${encodeURIComponent(callsign)}`);
   }
@@ -664,6 +685,44 @@ export interface AdifExportRequest {
   fromDate?: string;
   toDate?: string;
   qsoIds?: string[];
+}
+
+export interface LotwUploadFilter {
+  dateFrom?: string;
+  dateTo?: string;
+  stationCallsign?: string;
+  bands?: string[];
+  modes?: string[];
+  includeIgnored?: boolean;
+  includeNotSent?: boolean;
+}
+
+export interface LotwUploadResult {
+  qsoCount: number;
+  success: boolean;
+  tqslExitCode: number;
+  message: string;
+  markedAsSent: number;
+}
+
+export interface LotwPreviewItem {
+  id: string;
+  callsign: string;
+  qsoDate: string;
+  band: string;
+  mode: string;
+  lotwSent: string | null;
+}
+
+export interface LotwPreviewResponse {
+  count: number;
+  sample: LotwPreviewItem[];
+}
+
+export interface LotwTestTqslResponse {
+  ok: boolean;
+  version: string | null;
+  error: string | null;
 }
 
 // Contest Types

--- a/src/Log4YM.Web/src/api/signalr.ts
+++ b/src/Log4YM.Web/src/api/signalr.ts
@@ -567,6 +567,15 @@ export interface QrzSyncProgressEvent {
   message: string | null;
 }
 
+// LOTW Upload types
+export interface LotwUploadProgressEvent {
+  stage: string; // "preparing" | "signing" | "uploading" | "done" | "error"
+  qsoCount: number;
+  isComplete: boolean;
+  tqslExitCode: number | null;
+  message: string | null;
+}
+
 // ADIF Import types
 export interface AdifImportProgressEvent {
   total: number;
@@ -649,6 +658,8 @@ type EventHandlers = {
   onSmartUnlinkStatus?: (evt: SmartUnlinkStatusEvent) => void;
   // QRZ Sync handlers
   onQrzSyncProgress?: (evt: QrzSyncProgressEvent) => void;
+  // LOTW Upload handlers
+  onLotwUploadProgress?: (evt: LotwUploadProgressEvent) => void;
   // ADIF Import handlers
   onAdifImportProgress?: (evt: AdifImportProgressEvent) => void;
   // DX Cluster handlers
@@ -991,6 +1002,11 @@ class SignalRService {
     // QRZ Sync events
     this.connection.on('OnQrzSyncProgress', (evt: QrzSyncProgressEvent) => {
       this.handlers.onQrzSyncProgress?.(evt);
+    });
+
+    // LOTW Upload events
+    this.connection.on('OnLotwUploadProgress', (evt: LotwUploadProgressEvent) => {
+      this.handlers.onLotwUploadProgress?.(evt);
     });
 
     // ADIF Import events

--- a/src/Log4YM.Web/src/components/SettingsPanel.tsx
+++ b/src/Log4YM.Web/src/components/SettingsPanel.tsx
@@ -34,6 +34,9 @@ import {
   Sun,
   Moon,
   BarChart3,
+  CloudUpload,
+  FileCode,
+  FolderOpen,
 } from 'lucide-react';
 import { useSettingsStore, SettingsSection, StationSettings } from '../store/settingsStore';
 import { gridToLatLon } from '../utils/maidenhead';
@@ -54,6 +57,12 @@ const SETTINGS_SECTIONS: { id: SettingsSection; name: string; icon: React.ReactN
     name: 'QRZ.com',
     icon: <Globe className="w-5 h-5" />,
     description: 'QRZ lookup credentials',
+  },
+  {
+    id: 'lotw',
+    name: 'LOTW',
+    icon: <CloudUpload className="w-5 h-5" />,
+    description: 'TQSL binary path for LOTW upload',
   },
   {
     id: 'rotator',
@@ -464,6 +473,182 @@ function QrzSettingsSection() {
             </span>
           )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+// LOTW Settings Section — minimal: just what the upload path needs (TQSL binary + optional
+// station location). LOTW user/password are only needed for the confirmation-download phase,
+// which is a future add-on — not included here.
+function LotwSettingsSection() {
+  const { settings, updateLotwSettings } = useSettingsStore();
+  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [testMessage, setTestMessage] = useState('');
+
+  const lotw = settings.lotw;
+
+  const handleTest = async () => {
+    if (!lotw.tqslPath) return;
+    setTestStatus('testing');
+    setTestMessage('');
+    try {
+      const response = await fetch('/api/lotw/test-tqsl', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: lotw.tqslPath }),
+      });
+      const data = await response.json();
+      if (data.ok) {
+        setTestStatus('success');
+        setTestMessage(data.version || 'TQSL found');
+      } else {
+        setTestStatus('error');
+        setTestMessage(data.error || 'Could not run TQSL');
+      }
+    } catch {
+      setTestStatus('error');
+      setTestMessage('Failed to reach backend');
+    }
+    setTimeout(() => { setTestStatus('idle'); setTestMessage(''); }, 5000);
+  };
+
+  // Shown only when running under Electron — the preload script exposes the native picker.
+  // In browser/Vite-dev, the user types/pastes the path manually.
+  const hasElectronFilePicker = typeof window !== 'undefined'
+    && (window as unknown as { electronAPI?: { selectFile?: unknown } }).electronAPI?.selectFile !== undefined;
+
+  const handleBrowse = async () => {
+    const api = (window as unknown as { electronAPI: { selectFile: (opts: {
+      title?: string;
+      defaultPath?: string;
+      filters?: { name: string; extensions: string[] }[];
+    }) => Promise<string | null> } }).electronAPI;
+
+    // Platform-aware filters. On macOS the user usually drills into Tqsl.app/Contents/MacOS/tqsl,
+    // so we don't restrict by extension there. Windows wants .exe.
+    const platform = navigator.platform.toLowerCase();
+    const filters = platform.includes('win')
+      ? [{ name: 'Executables', extensions: ['exe'] }, { name: 'All Files', extensions: ['*'] }]
+      : [{ name: 'All Files', extensions: ['*'] }];
+
+    const picked = await api.selectFile({
+      title: 'Locate tqsl executable',
+      defaultPath: lotw.tqslPath || undefined,
+      filters
+    });
+    if (picked) updateLotwSettings({ tqslPath: picked });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold font-ui text-dark-200 mb-1">LOTW (Logbook of The World)</h3>
+        <p className="text-sm text-dark-300">
+          Sign and upload QSOs to ARRL LOTW via your local TQSL install.
+          TQSL must be installed separately — download from{' '}
+          <a
+            href="https://lotw.arrl.org/lotw-help/installation/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-primary hover:underline"
+          >
+            ARRL
+          </a>.
+        </p>
+      </div>
+
+      {/* Enable toggle */}
+      <div className="flex items-center justify-between p-4 bg-dark-700/50 rounded-lg border border-glass-100">
+        <div>
+          <p className="font-medium font-ui text-dark-200">Enable LOTW Upload</p>
+          <p className="text-sm text-dark-300">Shows a "Push to LOTW" button in Log History</p>
+        </div>
+        <button
+          onClick={() => updateLotwSettings({ enabled: !lotw.enabled })}
+          className={`relative w-11 h-6 rounded-full transition-colors ${
+            lotw.enabled ? 'bg-accent-success' : 'bg-dark-600 border border-dark-400'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform duration-200 ${
+              lotw.enabled ? 'translate-x-5' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className={`space-y-4 ${!lotw.enabled ? 'opacity-50 pointer-events-none' : ''}`}>
+        {/* TQSL binary path */}
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
+            <FileCode className="w-4 h-4 text-accent-primary" />
+            Path to TQSL Executable
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={lotw.tqslPath}
+              onChange={(e) => updateLotwSettings({ tqslPath: e.target.value })}
+              placeholder="Not set — click Browse to locate tqsl"
+              className="glass-input w-full font-mono text-sm"
+              disabled={!lotw.enabled}
+              spellCheck={false}
+            />
+            {hasElectronFilePicker && (
+              <button
+                onClick={handleBrowse}
+                disabled={!lotw.enabled}
+                className="glass-button px-4 py-2 flex items-center gap-2 disabled:opacity-50 whitespace-nowrap"
+                title="Browse for the tqsl executable"
+              >
+                <FolderOpen className="w-4 h-4" />
+                <span>Browse</span>
+              </button>
+            )}
+            <button
+              onClick={handleTest}
+              disabled={!lotw.tqslPath || testStatus === 'testing'}
+              className="glass-button px-4 py-2 flex items-center gap-2 disabled:opacity-50 whitespace-nowrap"
+            >
+              {testStatus === 'testing' && <Loader2 className="w-4 h-4 animate-spin" />}
+              {testStatus === 'success' && <CheckCircle className="w-4 h-4 text-accent-success" />}
+              {testStatus === 'error' && <AlertCircle className="w-4 h-4 text-accent-danger" />}
+              {testStatus === 'idle' && <CheckCircle className="w-4 h-4" />}
+              <span>{testStatus === 'testing' ? 'Testing...' : 'Test'}</span>
+            </button>
+          </div>
+          {testMessage && (
+            <p className={`text-xs ${testStatus === 'success' ? 'text-accent-success' : 'text-accent-danger'}`}>
+              {testMessage}
+            </p>
+          )}
+          <p className="text-xs text-dark-300">
+            Absolute path to the tqsl binary. Log4YM shells out to it for LOTW signing and upload —
+            same mechanism TQSL uses when you run it manually.
+          </p>
+        </div>
+
+        {/* Optional station location override */}
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm font-medium font-ui text-dark-200">
+            <User className="w-4 h-4 text-accent-primary" />
+            TQSL Station Location <span className="text-xs text-dark-300">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={lotw.stationCallsign}
+            onChange={(e) => updateLotwSettings({ stationCallsign: e.target.value })}
+            placeholder="Leave blank to use TQSL's default"
+            className="glass-input w-full"
+            disabled={!lotw.enabled}
+          />
+          <p className="text-xs text-dark-300">
+            Passed to TQSL as <code className="font-mono">-l &lt;name&gt;</code>.
+            Useful if your TQSL has multiple station locations configured.
+          </p>
+        </div>
+
       </div>
     </div>
   );
@@ -2078,6 +2263,8 @@ export function SettingsPanel() {
         return <StationSettingsSection />;
       case 'qrz':
         return <QrzSettingsSection />;
+      case 'lotw':
+        return <LotwSettingsSection />;
       case 'rotator':
         return <RotatorSettingsSection />;
       case 'database':

--- a/src/Log4YM.Web/src/hooks/useSignalR.ts
+++ b/src/Log4YM.Web/src/hooks/useSignalR.ts
@@ -39,6 +39,7 @@ export function useSignalRConnection() {
     removeSmartUnlinkRadio,
     setSmartUnlinkRadios,
     setQrzSyncProgress,
+    setLotwUploadProgress,
     setAdifImportProgress,
     setSelectedSpot,
     setLogHistoryCallsignFilter,
@@ -311,6 +312,11 @@ export function useSignalRConnection() {
           onQrzSyncProgress: (evt) => {
             console.log('QRZ sync progress:', evt.completed, '/', evt.total);
             setQrzSyncProgress(evt);
+          },
+          // LOTW Upload handler
+          onLotwUploadProgress: (evt) => {
+            console.log('LOTW upload progress:', evt.stage, evt.message);
+            setLotwUploadProgress(evt);
           },
           // ADIF Import handler
           onAdifImportProgress: (evt) => {

--- a/src/Log4YM.Web/src/plugins/LogHistoryPlugin.tsx
+++ b/src/Log4YM.Web/src/plugins/LogHistoryPlugin.tsx
@@ -10,6 +10,7 @@ import { api, QsoResponse, UpdateQsoRequest, AdifImportResponse } from '../api/c
 import { GlassPanel } from '../components/GlassPanel';
 import { getCountryFlag } from '../core/countryFlags';
 import { useAppStore } from '../store/appStore';
+import { useSettingsStore } from '../store/settingsStore';
 import { useAgGridState } from '../hooks/useAgGridState';
 
 // Common RST values for phone modes (SSB, AM, FM)
@@ -116,7 +117,9 @@ export function LogHistoryPlugin() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const queryClient = useQueryClient();
-  const { qrzSyncProgress, setQrzSyncProgress, adifImportProgress, setAdifImportProgress, logHistoryCallsignFilter } = useAppStore();
+  const { qrzSyncProgress, setQrzSyncProgress, adifImportProgress, setAdifImportProgress, logHistoryCallsignFilter, lotwUploadProgress, setLotwUploadProgress } = useAppStore();
+  const lotwEnabled = useSettingsStore((s) => s.settings.lotw.enabled);
+  const [isLotwUploading, setIsLotwUploading] = useState(false);
 
   const handleSyncToQrz = useCallback(async () => {
     if (isSyncing) return;
@@ -130,6 +133,40 @@ export function LogHistoryPlugin() {
       setIsSyncing(false);
     }
   }, [isSyncing, setQrzSyncProgress]);
+
+  const handlePushToLotw = useCallback(async () => {
+    if (isLotwUploading) return;
+    setIsLotwUploading(true);
+    setLotwUploadProgress(null);
+    try {
+      const result = await api.uploadToLotw({});
+      // Belt-and-suspenders: surface the final result via the progress banner even
+      // if SignalR didn't deliver (disconnected, slow, whatever). Same shape as the
+      // LotwUploadProgressEvent the backend broadcasts.
+      setLotwUploadProgress({
+        stage: result.success ? 'done' : 'error',
+        qsoCount: result.qsoCount,
+        isComplete: true,
+        tqslExitCode: result.tqslExitCode,
+        message: result.message,
+      });
+      if (result.success) {
+        // Marked-sent flags may have flipped — refresh the grid.
+        queryClient.invalidateQueries({ queryKey: ['qsos'] });
+      }
+    } catch (error) {
+      console.error('Failed to push to LOTW:', error);
+      setLotwUploadProgress({
+        stage: 'error',
+        qsoCount: 0,
+        isComplete: true,
+        tqslExitCode: -1,
+        message: error instanceof Error ? error.message : 'Request failed',
+      });
+    } finally {
+      setIsLotwUploading(false);
+    }
+  }, [isLotwUploading, setLotwUploadProgress, queryClient]);
 
   const handleCancelSync = useCallback(async () => {
     try {
@@ -409,6 +446,25 @@ export function LogHistoryPlugin() {
               )}
               <span className="text-xs">Push to QRZ</span>
             </button>
+            {lotwEnabled && (
+              <button
+                onClick={handlePushToLotw}
+                disabled={isLotwUploading}
+                className="glass-button p-1.5 flex items-center gap-1.5 text-accent-warning hover:text-accent-primary disabled:opacity-50 disabled:cursor-not-allowed"
+                title="Sign and upload eligible QSOs to ARRL LOTW via TQSL"
+              >
+                {isLotwUploading ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <CloudUpload className="w-4 h-4" />
+                )}
+                <span className="text-xs">
+                  {lotwUploadProgress && !lotwUploadProgress.isComplete
+                    ? `LOTW: ${lotwUploadProgress.stage}`
+                    : 'Push to LOTW'}
+                </span>
+              </button>
+            )}
           </div>
         </div>
       }
@@ -507,6 +563,57 @@ export function LogHistoryPlugin() {
             </div>
           </div>
         )}
+
+        {/* LOTW Upload status — live progress or final result (error or success).
+            Message may be multi-line (e.g. includes TQSL's own stdout); we split so the
+            "TQSL output:" block renders as a monospace block underneath the summary. */}
+        {lotwUploadProgress && (() => {
+          const raw = lotwUploadProgress.message
+            || `LOTW: ${lotwUploadProgress.stage}${lotwUploadProgress.qsoCount > 0 ? ` (${lotwUploadProgress.qsoCount} QSOs)` : ''}`;
+          const splitIdx = raw.indexOf('\n\nTQSL output:\n');
+          const summary = splitIdx >= 0 ? raw.slice(0, splitIdx) : raw;
+          const tqslOutput = splitIdx >= 0 ? raw.slice(splitIdx + '\n\nTQSL output:\n'.length) : '';
+          return (
+            <div className={`bg-dark-700/80 rounded-lg p-3 border ${
+              lotwUploadProgress.stage === 'error'
+                ? 'border-accent-danger/30'
+                : lotwUploadProgress.isComplete
+                  ? 'border-accent-success/30'
+                  : 'border-accent-info/30'
+            }`}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-start gap-2 flex-1 min-w-0">
+                  <div className="mt-0.5 shrink-0">
+                    {!lotwUploadProgress.isComplete && (
+                      <Loader2 className="w-4 h-4 text-accent-info animate-spin" />
+                    )}
+                    {lotwUploadProgress.isComplete && lotwUploadProgress.stage === 'error' && (
+                      <AlertTriangle className="w-4 h-4 text-accent-danger" />
+                    )}
+                    {lotwUploadProgress.isComplete && lotwUploadProgress.stage !== 'error' && (
+                      <CheckCircle className="w-4 h-4 text-accent-success" />
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-dark-200 font-ui whitespace-pre-wrap">{summary}</div>
+                    {tqslOutput && (
+                      <pre className="mt-2 text-xs text-dark-300 font-mono bg-dark-800/60 rounded px-2 py-1.5 overflow-x-auto whitespace-pre-wrap">{tqslOutput}</pre>
+                    )}
+                  </div>
+                </div>
+                {lotwUploadProgress.isComplete && (
+                  <button
+                    onClick={() => setLotwUploadProgress(null)}
+                    className="text-dark-300 hover:text-dark-200 shrink-0"
+                    title="Dismiss"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })()}
 
         {/* ADIF Import Starting (before first progress event) */}
         {importMutation.isPending && !adifImportProgress && (

--- a/src/Log4YM.Web/src/store/appStore.ts
+++ b/src/Log4YM.Web/src/store/appStore.ts
@@ -114,6 +114,10 @@ interface AppState {
   qrzSyncProgress: QrzSyncProgress | null;
   setQrzSyncProgress: (progress: QrzSyncProgress | null) => void;
 
+  // LOTW Upload
+  lotwUploadProgress: LotwUploadProgress | null;
+  setLotwUploadProgress: (progress: LotwUploadProgress | null) => void;
+
   // ADIF Import
   adifImportProgress: AdifImportProgress | null;
   setAdifImportProgress: (progress: AdifImportProgress | null) => void;
@@ -190,6 +194,14 @@ export interface QrzSyncProgress {
   failed: number;
   isComplete: boolean;
   currentCallsign: string | null;
+  message: string | null;
+}
+
+export interface LotwUploadProgress {
+  stage: string; // "preparing" | "signing" | "uploading" | "done" | "error"
+  qsoCount: number;
+  isComplete: boolean;
+  tqslExitCode: number | null;
   message: string | null;
 }
 
@@ -456,6 +468,10 @@ export const useAppStore = create<AppState>((set) => ({
   // QRZ Sync
   qrzSyncProgress: null,
   setQrzSyncProgress: (progress) => set({ qrzSyncProgress: progress }),
+
+  // LOTW Upload
+  lotwUploadProgress: null,
+  setLotwUploadProgress: (progress) => set({ lotwUploadProgress: progress }),
 
   // ADIF Import
   adifImportProgress: null,

--- a/src/Log4YM.Web/src/store/settingsStore.ts
+++ b/src/Log4YM.Web/src/store/settingsStore.ts
@@ -18,6 +18,15 @@ export interface QrzSettings {
   enabled: boolean;
 }
 
+export interface LotwSettings {
+  enabled: boolean;
+  // Absolute path to the local TQSL binary (e.g. C:\Program Files\TrustedQSL\tqsl.exe).
+  // Entered manually; TQSL must be installed separately.
+  tqslPath: string;
+  // Optional TQSL station location name (passed as `-l <name>`); empty = TQSL default.
+  stationCallsign: string;
+}
+
 export interface AppearanceSettings {
   theme: 'dark' | 'light';
   compactMode: boolean;
@@ -151,6 +160,7 @@ export interface AiSettings {
 export interface Settings {
   station: StationSettings;
   qrz: QrzSettings;
+  lotw: LotwSettings;
   appearance: AppearanceSettings;
   rotator: RotatorSettings;
   radio: RadioSettings;
@@ -163,7 +173,7 @@ export interface Settings {
   gridStates: Record<string, string>;
 }
 
-export type SettingsSection = 'station' | 'qrz' | 'rotator' | 'database' | 'appearance' | 'map' | 'header' | 'ai' | 'spectrum' | 'about';
+export type SettingsSection = 'station' | 'qrz' | 'lotw' | 'rotator' | 'database' | 'appearance' | 'map' | 'header' | 'ai' | 'spectrum' | 'about';
 
 interface SettingsState {
   // Settings data
@@ -186,6 +196,7 @@ interface SettingsState {
   // Settings updates
   updateStationSettings: (station: Partial<StationSettings>) => void;
   updateQrzSettings: (qrz: Partial<QrzSettings>) => void;
+  updateLotwSettings: (lotw: Partial<LotwSettings>) => void;
   updateAppearanceSettings: (appearance: Partial<AppearanceSettings>) => void;
   updateRotatorSettings: (rotator: Partial<RotatorSettings>) => void;
   updateRadioSettings: (radio: Partial<RadioSettings>) => void;
@@ -223,6 +234,11 @@ const defaultSettings: Settings = {
     password: '',
     apiKey: '',
     enabled: false,
+  },
+  lotw: {
+    enabled: false,
+    tqslPath: '',
+    stationCallsign: '',
   },
   appearance: {
     theme: 'dark',
@@ -354,6 +370,16 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       settings: {
         ...state.settings,
         qrz: { ...state.settings.qrz, ...qrz },
+      },
+      isDirty: true,
+    })),
+
+  // LOTW settings
+  updateLotwSettings: (lotw) =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        lotw: { ...state.settings.lotw, ...lotw },
       },
       isDirty: true,
     })),
@@ -578,6 +604,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
         const mergedSettings: Settings = {
           station: { ...defaultSettings.station, ...settings.station },
           qrz: { ...defaultSettings.qrz, ...settings.qrz },
+          lotw: { ...defaultSettings.lotw, ...settings.lotw },
           appearance: { ...defaultSettings.appearance, ...settings.appearance },
           rotator: { ...defaultSettings.rotator, ...settings.rotator },
           radio: {


### PR DESCRIPTION
Closes #165

## Summary

- New **Settings → LOTW** section: TQSL executable path (with native file picker + Test button), optional TQSL station location, enable toggle.
- New **Push to LOTW** button in Log History (gated on the enable toggle). Shells out to `tqsl -d -q -u <adif>`, marks QSOs as sent on exit 0/9, streams progress over a new `OnLotwUploadProgress` SignalR event. Preflights guard elevated runs (TQSL refuses admin), missing paths, and non-tqsl binaries.
- ADIF export fixes surfaced while debugging silent LOTW drops: uppercase `BAND`/`MODE`/`CALL`, `PadLeft` in `FormatTime` (was `PadRight` — "945" became "9450"), and both `QSO_DATE` + `TIME_ON` derived from one `ToUniversalTime()` call so LiteDB's `Kind=Local` round-trip can't make LOTW see a future-dated QSO.
- Signed ADIF written under `%APPDATA%\Log4YM\lotw-uploads\`, kept on failure for inspection, deleted on success.

## Test plan

- [ ] Settings → LOTW → browse to `tqsl.exe`, Test returns version
- [ ] Standard-user run only (elevation preflight fires the clear error if run as admin)
- [ ] Push to LOTW on a single QSO; green banner with TQSL's own summary
- [ ] QSO appears on the LOTW website within a few minutes
- [ ] Failure path (bad cert, wrong TQSL path) keeps the ADIF and shows the path in the red banner
- [ ] `LotwServiceTests` cover exit-code mapping (0, 9, 11) and the two preflight rejections